### PR TITLE
Incremental compile fix

### DIFF
--- a/src/atoms.jl
+++ b/src/atoms.jl
@@ -55,6 +55,8 @@ Returns the coordinate associated with an atomic position.
 """
 coord(a::AtomPosition) = a.pos
 
+Base.getindex(a::AtomPosition, ind) = a.pos[ind]
+
 """
     AtomList{D} <: AbstractRealSpaceData{D}
 

--- a/src/data.jl
+++ b/src/data.jl
@@ -373,9 +373,10 @@ struct ProjectedDensityOfStates
         fermi::Real,
         energy::AbstractVector{<:Real},
         dos::AbstractMatrix{<:Real},
+        int::AbstractMatrix{<:Real}
     )
         @assert length(energy) == size(dos,2) "Number of energy and DOS entries do not match."
-        return new(fermi, energy, dos)
+        return new(fermi, energy, dos, int)
     end
 end
 


### PR DESCRIPTION
Before this fix: the package would build, but would warn about fatally broken incremental compilation due to an unintended override of the inner constructor of `ProjectedDensityofStates`.

Not sure where the change to `Base.getindex(::AtomList)` happened, but I'll just leave that in for now...I'll try to be better about that in the future...