### PR TITLE
Fixed improper use of `BasisVectors` that broke `readXSF3D()`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Xtal"
 uuid = "b7bf5f09-dce4-461b-b741-5180c76f4cfe"
 authors = ["Brandon Flores <bsflores@wisc.edu>", "Amber Lim <xalim@wisc.edu>"]
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/filetypes.jl
+++ b/src/filetypes.jl
@@ -54,7 +54,6 @@ function readXSF3D(
     function getlattice!(itr)
         vecs = [parse.(Float64, split(iterate(itr)[1])) for n in 1:3]
         @debug string("Found vectors:\n", vecs)
-        # Returns a Matrix{Float64}
         return BasisVectors{3}(hcat(vecs...))
     end
     # Function for getting 3D lists of atoms

--- a/src/lattices.jl
+++ b/src/lattices.jl
@@ -71,6 +71,10 @@ Base.zeros(::Type{BasisVectors{D}}) where D = zeros(SVector{D,SVector{D,Float64}
 Base.:*(b::BasisVectors, s::Number) = BasisVectors(matrix(b) * s)
 Base.:/(b::BasisVectors, s::Number) = BasisVectors(matrix(b) / s)
 
+# And multiplication/division by vectors
+Base.:*(b::BasisVectors, v::AbstractVector) = matrix(b) * v
+Base.:\(b::BasisVectors, v::AbstractVector) = matrix(b) \ v
+
 """
     dual(b::BasisVectors)
 


### PR DESCRIPTION
We still need to figure out how to best handle the matrix type stability problem and the use of `BasisVectors` because this is a little annoying.