### PR TITLE
Fixed string escaping that wasn't compatible with Julia 1.6

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Xtal"
 uuid = "b7bf5f09-dce4-461b-b741-5180c76f4cfe"
 authors = ["Brandon Flores <bsflores@wisc.edu>", "Amber Lim <xalim@wisc.edu>"]
-version = "0.1.6"
+version = "0.1.7"
 
 [deps]
 ComputedFieldTypes = "459fdd68-db75-56b8-8c15-d717a790f88e"

--- a/src/data.jl
+++ b/src/data.jl
@@ -302,8 +302,9 @@ struct HKLData{D,T} <: AbstractReciprocalSpaceData{D}
         # The size of the array should match the bounds given
         # For instance, a HKLData with bounds  [-10:10, -10:10, -10:10] should Be
         # [21, 21, 21]
-        @assert [s for s in size(data)] == [length(r) for r in bounds] "Array size \
-        incompatible with bounds."
+        @assert [s for s in size(data)] == [length(r) for r in bounds] string(
+            "Array size incompatible with bounds."
+        )
         return new(data, bounds)
     end
 end
@@ -383,14 +384,16 @@ struct ReciprocalWavefunction{D,T<:Real} <: AbstractReciprocalSpaceData{D}
         waves::AbstractVector{<:AbstractVector{HKLData{D,Complex{T}}}}
     ) where {D,T<:Real}
         # Number of k-points should equal the length of the waves vector
-        @assert length(waves) == nkpt(bands) "Number of k-points and number of planewave data \
-        entries do not match."
+        @assert length(waves) == nkpt(bands) string(
+            "Number of k-points and number of planewave data entries do not match."
+        )
         # Number of band entries per k-point should be the same
         lw = length.(waves)
         @assert _allsame(lw) "The number of bands per k-point is inconsistent."
         # There should be the same number of planewave sets as there are bands per k-point``
-        @assert first(lw) == nband(bands) "Number of bands and number of planewave data \
-        entries do not match."
+        @assert first(lw) == nband(bands) string(
+            "Number of bands and number of planewave data entries do not match."
+        )
         return new(rlatt, bands, waves)
     end
 end

--- a/src/lattices.jl
+++ b/src/lattices.jl
@@ -150,8 +150,7 @@ struct ReciprocalLattice{D} <: AbstractLattice{D}
             "The smaller set of basis vectors is not expressed in terms of integer reciprocals of",
             "the larger set of basis vectors."
         )
-        new(prim, conv)
-        new(prim,conv)
+        return new(prim, conv)
     end
 end
 

--- a/src/lattices.jl
+++ b/src/lattices.jl
@@ -124,9 +124,10 @@ struct RealLattice{D} <: AbstractLattice{D}
         conv::BasisVectors{D}
     ) where D
         # Perform checks on the lattice pairs
-        @assert all(x -> x - round(Int, x) < TOL_DEF, matrix(prim)\matrix(conv)) "The larger set \
-        of basis vectors is not expressed in terms of integer multiples of the smaller set of \
-        basis vectors."
+        @assert all(x -> x - round(Int, x) < TOL_DEF, matrix(prim)\matrix(conv)) string(
+            "The larger set of basis vectors is not expressed in terms of integer multiples of",
+            "the smaller set of basis vectors."
+        )
         new(prim, conv)
     end
 end
@@ -145,9 +146,10 @@ struct ReciprocalLattice{D} <: AbstractLattice{D}
         conv::BasisVectors{D}
     ) where D
         # Perform checks on the lattice pairs
-        @assert all(x -> x - round(Int, x) < TOL_DEF, matrix(conv)\matrix(prim)) "The larger set \
-        of basis vectors is not expressed in terms of integer multiples of the smaller set of \
-        basis vectors."
+        @assert all(x -> x - round(Int, x) < TOL_DEF, matrix(conv)\matrix(prim)) string(
+            "The smaller set of basis vectors is not expressed in terms of integer reciprocals of",
+            "the larger set of basis vectors."
+        )
         new(prim, conv)
         new(prim,conv)
     end


### PR DESCRIPTION
The string escaping I used in some of the long error strings associated with `@assert` were breaking compilation on Julia 1.6.

The fix has been tested in Julia 1.6.6. In the future, we'll have to enforce a standard, 1.6-compatible method of string splitting.