### PR TITLE
Small fixes to XSF reading

### DIFF
--- a/src/filetypes.jl
+++ b/src/filetypes.jl
@@ -163,14 +163,24 @@ function readXSF3D(
             @debug string("natom = ", natom)
             # The next lines have all of the atoms
             atom_list = getatoms!(iter, prim, natom)
-        # Get conventional cell atomic coordinates
-        # But do we need them?
         elseif contains(ln, "CONVCOORD") && isempty(atom_list)
             # TODO: complete this, but it's low priority
             # The PRIMCOORD block gets everything we need right now
         elseif contains(ln, "ATOMS") && isempty(atom_list)
             # TODO: complete this, but it's low priority
             # The PRIMCOORD block gets everything we need right now
+        elseif contains(ln, "DIM-GROUP")
+            # Check the line below and see if the structure is periodic
+            ln = iterate(iter)[1]
+            if first(strip(ln)) == '3' && spgrp == 0
+                # If the structure is a crystal, set spgrp to 1
+                # spgrp 0 implies a non-periodic structure
+                spgrp = 1
+            end
+        elseif contains(ln, "CRYSTAL") && spgrp == 0
+            # If the structure is a crystal, set spgrp to 1
+            # spgrp 0 implies a non-periodic structure
+            spgrp = 1
         end
     end
     # If the conventional cell hasn't been defined, generate it

--- a/src/filetypes.jl
+++ b/src/filetypes.jl
@@ -184,13 +184,18 @@ function readXSF3D(
 end
 
 """
-    readXSF3D(filename::AbstractString)
+    readXSF3D(
+        filename::AbstractString;
+        spgrp::Integer = 0,
+        origin::AbstractVector{<:Real} = [0, 0, 0]
+        ctr::Symbol = :P
+    ) -> CrystalWithDatasets{3}
 
 Reads an XSF file at path `filename`.
 """
-function readXSF3D(filename::AbstractString)
+function readXSF3D(filename::AbstractString; kwargs...)
     return open(filename) do io
-        readXSF3D(io)
+        readXSF3D(io; kwargs...)
     end
 end
 


### PR DESCRIPTION
Calling `readXSF3D()` on a filename now supports keyword arguments, and space group number is automatically converted from 0 to 1 when a periodic structure is detected.