### PR TITLE
Fix to get `writeXSF()` working again

### DIFF
--- a/src/atoms.jl
+++ b/src/atoms.jl
@@ -116,9 +116,10 @@ function cartesian(l::AtomList{D}) where D
     # If the basis vectors are zero we're assuming Cartesian coordinates
     basis(l) == zeros(BasisVectors{D}) && return l
     newlist = map(a -> cartesian(l.basis, a), l.coord)
-    return AtomList{D}(zeros(Basis{D}), newlist)
+    return AtomList{D}(zeros(BasisVectors{D}), newlist)
 end
 
+# TODO: clean up these method definitions into something that makes more sense
 """
     cartesian(b::AbstractMatrix{<:Real}, a::AtomPosition{D}) -> AtomPosition{D}
 
@@ -129,6 +130,8 @@ function cartesian(b::AbstractMatrix{<:Real}, a::AtomPosition{D}) where D
     newpos = b * a.pos
     return AtomPosition{D}(a.name, a.num, newpos)
 end
+
+cartesian(b::BasisVectors{D}, a::AtomPosition{D}) where D = cartesian(matrix(b), a)
 
 """
     reduce_coords(basis::AbstractMatrix{<:Real}, a::AtomPosition; incell=false)

--- a/src/crystals.jl
+++ b/src/crystals.jl
@@ -66,6 +66,9 @@ function Base.convert(::Type{Crystal{D}}, xtaldata::CrystalWithDatasets{D,K,V}) 
     return xtaldata.xtal
 end
 
+Crystal(xtaldata::CrystalWithDatasets{D,K,V}) where {D,K,V} = xtaldata.xtal
+data(xtaldata::CrystalWithDatasets{D,K,V}) where {D,K,V} = xtaldata.data
+
 RealLattice(xtal::Crystal) = xtal.latt
 ReciprocalLattice(xtal::Crystal) = ReciprocalLattice(xtal.latt)
 

--- a/src/filetypes.jl
+++ b/src/filetypes.jl
@@ -221,7 +221,7 @@ function writeXSF(io::IO, xtal::Crystal{D}) where D
     println(io, D, "  1")
     # Primitive cell vectors
     println(io, "PRIMVEC")
-    for (n, x) in enumerate(prim(xtal))
+    for (n, x) in enumerate(matrix(prim(xtal)))
         @printf(io, "%20.14f  ", x)
         n % D == 0 && println(io)
     end
@@ -259,7 +259,7 @@ function writeXSF(io::IO, key, data::RealSpaceDataGrid{D,T}; periodic=true) wher
     end
     print(io, "\n" * " "^4)
     # Print the basis vectors for the grid
-    for (n, x) in enumerate(basis(data))
+    for (n, x) in enumerate(matrix(basis(data)))
         @printf(io, "%20.14f", x)
         n % D == 0 && print(io, "\n" * " "^4)
     end

--- a/src/software/abinit.jl
+++ b/src/software/abinit.jl
@@ -654,7 +654,7 @@ function read_abinit_density(io::IO)
     header = read_abinit_header(io)
     # Get the type of the datagrid (set by cplex in the header)
     T = (Float64, Complex{Float64})[header.cplex]
-    rho = read_abinit_datagrids(T, io, header.nspden, header.ngfft, conversion=BOHR2ANG^3)
+    rho = read_abinit_datagrids(T, io, header.nspden, header.ngfft)
     # Add each dataset to the dictionary
     data = Dict{String, RealSpaceDataGrid{3,T}}()
     # Convert the basis


### PR DESCRIPTION
It appears that this function was not updated after the changeover to `BasisVectors` (as opposed to `SMatrix`), and some of the methods that were being used to get components of `CrystalWithDatasets` were not actually present!