### PR TITLE
Consistent function names

### DIFF
--- a/src/Xtal.jl
+++ b/src/Xtal.jl
@@ -84,7 +84,8 @@ export AbstractLattice, AbstractCrystal, AbstractCrystalData, AbstractRealSpaceD
 # Methods and structs for working with crystal lattices
 include("lattices.jl")
 export BasisVectors, RealLattice, ReciprocalLattice
-export dual, prim, conv, cell_lengths, cell_volume, lattice2D, lattice3D, maxHKLindex
+export dual, prim, conv, cell_lengths, cell_volume, lengths, volume, lattice2D, lattice3D,
+       maxHKLindex
 # Methods and structs for working with atomic positions
 include("atoms.jl")
 export AtomPosition, AtomList

--- a/src/lattices.jl
+++ b/src/lattices.jl
@@ -253,21 +253,40 @@ function RealLattice{3}(M::AbstractMatrix{<:Real}; prim=false, ctr=:P)
 end
 
 """
-    cell_lengths(M::AbstractMatrix)
+    cell_lengths(M::AbstractMatrix) -> Vector{Float64}
 
 Returns the lengths of the constituent vectors in a matrix representing cell vectors.
 """
 cell_lengths(M::AbstractMatrix) = [norm(M[:,n]) for n = 1:size(M,2)]
+# TODO: perhaps this is not necessary anymore
+# But removing it might break the API
 cell_lengths(b::BasisVectors) = cell_lengths(matrix(b))
 
 """
-    cell_volume(M::AbstractMatrix)
+    lengths(b::BasisVectors) -> Vector{Float64}
+
+Returns the lengths of the constituent vectors in a matrix representing cell vectors.
+"""
+lengths(b::BasisVectors) = cell_lengths(matrix(b))
+
+"""
+    cell_volume(M::AbstractMatrix) -> Float64
 
 Returns the volume of a unit cell defined by a matrix. This volume does not carry the sign
 (negative for cells that do not follow the right hand rule).
 """
 cell_volume(M::AbstractMatrix) = abs(det(M))
+# TODO: perhaps this is not necessary anymore
+# But removing it might break the API
 cell_volume(b::BasisVectors) = cell_volume(matrix(b))
+
+"""
+    volume(b::BasisVectors) -> Float64
+
+Returns the volume of a unit cell defined by a matrix. This volume does not carry the sign
+(negative for cells that do not follow the right hand rule).
+"""
+volume(b::BasisVectors) = cell_volume(matrix(b))
 
 """
     generate_pairs(D::Integer) -> Vector{NTuple{2,Int}}
@@ -321,7 +340,7 @@ cell_angle_deg(M::AbstractMatrix) = acosd.(cell_angle_cos(M))
 """
     lengths(L::AbstractLattice{D}; prim=false) -> SVector{D,Float64}
 
-Returns the cell vector lengths.
+Returns the cell vector lengths. By default, returns the lengths of the conventional cell vectors.
 """
 function lengths(L::AbstractLattice{D}; prim=false) where D
     prim ? M = prim(L) : M = conv(L)

--- a/src/software/abinit.jl
+++ b/src/software/abinit.jl
@@ -674,6 +674,21 @@ function read_abinit_density(io::IO)
     )
 end
 
+"""
+    read_abinit_density(filename::AbstractString)
+        -> CrystalWithDatasets{3,String,RealSpaceDataGrid{3,Float64}}
+
+Reads a FORTRAN binary formatted abinit density file. By default, abinit density files will have
+the suffix `DEN`, but no assumptions are made about suffixes.
+
+The header is used to automatically determine the file format, so this should read in any abinit
+density output (provided a function exists to parse that header).
+
+The number of datasets returned depends on the value of `nssppol` in the header, as calculations
+with explicit treatment of spin will return spin densities.
+
+Depending on the value of `cplex`, the datagrid(s) returned may be real or complex-valued.
+"""
 read_abinit_density(filename::AbstractString) = open(read_abinit_density, filename)
 
 function read_abinit_potential(io::IO)
@@ -702,6 +717,24 @@ function read_abinit_potential(io::IO)
     )
 end
 
+"""
+    read_abinit_potential(filename::AbstractString)
+        -> CrystalWithDatasets{3,String,RealSpaceDataGrid{3,T}} where T<:Union{Float64,ComplexF64}
+
+Reads a FORTRAN binary formatted abinit potential file. 
+
+By default, abinit potential files will end in `POT` for the external potential, `VHA` for the 
+Hartree potential, `VXC` for the exchange-correlation potential, and `VHXC` for the sum of both the
+Hartree and exchange-correlation potentials.
+
+The header is used to automatically determine the file format, so this should read in any abinit
+density output (provided a function exists to parse that header).
+
+The number of datasets returned depends on the value of `nssppol` in the header, as calculations
+with explicit treatment of spin will return spin-dependent potentials.
+
+Depending on the value of `cplex`, the datagrid(s) returned may be real or complex-valued.
+"""
 read_abinit_potential(filename::AbstractString) = open(read_abinit_potential, filename)
 
 """


### PR DESCRIPTION
I realized that `lengths()` and `volume()` were not defined for `BasisVectors` but they really need to be.

Also, `read_abinit_potential` and `read_abinit_density` needed docstrings.