### PR TITLE
HGH pseudopotentials - new features and fixes

### DIFF
--- a/src/potentials.jl
+++ b/src/potentials.jl
@@ -55,7 +55,7 @@ Although HGH pseudopotential data is freely available, and in principle we could
 existing HGH pseudopotentials into this package, this data structure allows alteration of the 
 pseudopotential parameters.
 """
-struct HGHPseudopotential <: AbstractPotential
+struct HGHPseudopotential <: AbstractPseudopotential
     # Atomic number
     zatom::Int8
     # Total charge
@@ -88,8 +88,15 @@ zatom(p::AbstractPotential) = p.zatom
 
 Gets the effective charge associated with a pseudopotential.
 """
-zion(psp::AbstractPseudopotential) = psp.zion
 zion(p::AbstractPotential) = zatom(p)
+zion(psp::AbstractPseudopotential) = psp.zion
+
+"""
+    xc(hgh::HGHPseudopotential) -> XCFunctional
+
+Gets the exchange-correlation functional associated with an HGH pseudopotential.
+"""
+xc(hgh::HGHPseudopotential) = hgh.pspxc
 
 """
     AlchemicalPotential{T<:AbstractPotential}

--- a/src/show.jl
+++ b/src/show.jl
@@ -213,3 +213,20 @@ function Base.show(
         print(io, "\n(higher order components omitted for brevity)")
     end
 end
+
+function Base.show(io::IO, ::MIME"text/plain", psp::HGHPseudopotential)
+    println(io, typeof(psp), " for ", ELEMENTS[zatom(psp)], " (+", zion(psp), "):")
+    println(io, "  rloc:    ", psp.rloc)
+    println(io, "  c:       ", psp.c)
+    println(io, "  r:       ", psp.r)
+    #=
+    println(io, "  h(s):    ")
+    println(io, "  h(p):    ")
+    println(io, "  h(d):    ")
+    println(io, "  h(f):    ")
+    println(io, "  k(s):    ", psp.k[])
+    println(io, "  k(p):    ", psp.k[])
+    println(io, "  k(d):    ", psp.k[])
+    println(io, "  k(f):    ", psp.k[])
+    =#
+end

--- a/src/software/abinit.jl
+++ b/src/software/abinit.jl
@@ -843,6 +843,7 @@ function readHGH(io::IO)
         h = cat([diagm(m[l,:]) for l in 1:(lmax+1)]..., dims=3)
         for l = 0:lmax
             # TODO: there must be a better way to do this
+            # These matrices have l values as their last dimension
             h[1,2,l+1] = -1/2*sqrt((2*l+3)/(2*l+5)) * h[2,2,l+1]
             h[1,3,l+1] = 1/2*sqrt((2*l+3)*(2*l+5)/((2*l+7)*(2*l+9))) * h[3,3,l+1]
             h[2,3,l+1] = -sqrt((2*l+5)^2/((2*l+7)*(2*l+9))) * h[3,3,l+1]
@@ -866,6 +867,7 @@ function readHGH(io::IO)
     c = SVector{4,Float64}(c1, c2, c3, c4)
     r = zeros(Float64, lmax + 1)
     # Generate matrices to store the diagonal h and k components for each l
+    # Diagonal matrices have l value as their first dimension
     hdiag = zeros(Float64, lmax + 1, 3)
     kdiag = zeros(Float64, lmax + 1, 3)
     # Get the s components (which have no corresponding spin-orbit parameters)


### PR DESCRIPTION
I added a `show()` method for `HGHPseudopotential` and the `xc()` function to identify what XC functional is intended to be used with the pseudopotential.

I've found that the reading of k values in HGH pseudopotentials is also completely broken, so that needs to be fixed before this branch can be merged.