### PR TITLE
Datagrid subtraction and indexing update

### DIFF
--- a/src/data.jl
+++ b/src/data.jl
@@ -50,8 +50,13 @@ function RealSpaceDataGrid(
     end
 end
 
-# Data in RealSpaceDataGrids can now be indexed
-Base.getindex(g::RealSpaceDataGrid, inds...) = getindex(g.grid, inds...)
+# getindex supports arbitrary integer indices for RealSpaceDataGrid
+function Base.getindex(g::RealSpaceDataGrid, inds...)
+    # Perform modulo math to get the indices
+    # WARNING: Julia % is the remainder function, not modulo!
+    imod = mod.(inds .- 1,  gridsize(g)) .+ 1
+    return getindex(grid(g), imod...)
+end
 
 # Iterator definitions: pass through matrix iteration
 Base.iterate(g::RealSpaceDataGrid) = iterate(grid(g))

--- a/src/data.jl
+++ b/src/data.jl
@@ -138,6 +138,11 @@ end
 
 Base.:*(g::RealSpaceDataGrid, s::Number) = s * g
 
+# Multiply everything in the datagrid by -1
+Base.:-(g::RealSpaceDataGrid) = RealSpaceDataGrid(basis(g), shift(g), -grid(g))
+# Subtract two datagrids
+Base.:-(g1::RealSpaceDataGrid, g2::RealSpaceDataGrid) = +(g1, -g2)
+
 """
     integrate(g::RealSpaceDataGrid{D,T<:Number}) -> <:Number
 


### PR DESCRIPTION
Now you can subtract and negate a `RealSpaceDataGrid`, and you can index them arbitrarily by any positive or negative index (which loops around, so that for `g::RealSpaceDataGrid{3,Float64}`,`g[0, 0, 0] === g[gridsize(g)]`)