### PR TITLE
Combine real and imaginary components of `FatBands` into a single field

### DIFF
--- a/src/data.jl
+++ b/src/data.jl
@@ -322,13 +322,12 @@ Stores information relevant to plotting fatbands.
 
 - FatBands.bands: matrix of energies at each [kpt, band].
 - FatBands.projband: array of lm-decomposed band structure. [orbital, ion, band, kpt].
-- FatBands.realband (and imagband): array of real/imaginary components to band structure.
+- FatBands.cband: array of complex-valued contributions to band structure.
 """
 struct FatBands{D} <: AbstractReciprocalSpaceData{D}
     bands::Matrix{Float64}
     projband::Array{Float64,4}
-    realband::Array{Float64,4}
-    imagband::Array{Float64,4}
+    cband::Array{Complex{Float64},4}
 end
 
 """


### PR DESCRIPTION
This change was merged (#40) but it appears to have been lost. This commit was reviewed by @xamberl so I'll merge ASAP (I might revert `dev` first)