### PR TITLE
Added new `HKLDict` type

### DIFF
--- a/src/Xtal.jl
+++ b/src/Xtal.jl
@@ -99,8 +99,8 @@ include("vectors.jl")
 # Abstract types used in type tree
 include("types.jl")
 export AbstractLattice, AbstractCrystal, AbstractCrystalData, AbstractRealSpaceData, 
-       AbstractReciprocalSpaceData, AbstractKPoints, AbstractDensityOfStates, AbstractPotential,
-       AbstractPseudopotential
+       AbstractReciprocalSpaceData, AbstractHKL, AbstractKPoints, AbstractDensityOfStates,
+       AbstractPotential, AbstractPseudopotential
 # Methods and structs for working with crystal lattices
 include("lattices.jl")
 export BasisVectors, RealLattice, ReciprocalLattice
@@ -116,7 +116,7 @@ export Crystal, CrystalWithDatasets
 export natom_template, data, prim, conv, volume
 # Methods and structs for working with different types of data associated with crystals
 include("data.jl")
-export RealSpaceDataGrid, KPointGrid, KPointList, BandAtKPoint, BandStructure, HKLData,
+export RealSpaceDataGrid, KPointGrid, KPointList, BandAtKPoint, BandStructure, HKLData, HKLDict,
        ReciprocalWavefunction, DensityOfStates, ProjectedDensityOfStates, FatBands, AtomicData,
        SphericalComponents, gaussian, smear
 export grid, gridsize, volume, voxelsize, integrate, nkpt, nband, fermi, energies, nelectrons

--- a/src/data.jl
+++ b/src/data.jl
@@ -404,6 +404,75 @@ function Base.zeros(
 end
 
 """
+    HKLDict{D,T}
+
+An alternative to `HKLData` uses a dictionary instead of an array as a backing field.
+
+This is a more space-efficient alternative to `HKLData` in the case of reciprocal space data with
+a large number of zero components. For wavefunction data, which is often specified to some energy
+cutoff that corresponds to a distance in reciprocal space, there are many zero valued elements to
+the array. Unspecified elements in an `HKLDict` are assumed to be zero.
+"""
+struct HKLDict{D,T} <: AbstractReciprocalSpaceData{D}
+    dict::Dict{SVector{D,Int},T}
+end
+
+Base.has_offset_axes(hkl::HKLDict) = true
+
+function Base.getindex(hkl::HKLDict{D,T}, inds...) where {D,T}
+    v = SVector{D,Int}(inds...)
+    if haskey(hkl.dict, v)
+        return hkl.dict[v]
+    else
+        # Return a zero element of some kind by default
+        return zero(T)
+    end
+end
+
+function Base.setindex!(hkl::HKLDict{D,T}, value::T, inds...) where {D,T}
+    hkl.dict[SVector{D,Int}(inds...)] = value
+end
+
+Base.keys(hkl::HKLDict) = keys(hkl.dict)
+
+Base.iterate(hkl::HKLDict) = iterate(hkl.dict)
+Base.iterate(hkl::HKLDict, i) = iterate(hkl.dict, i)
+
+"""
+    vectors(hkl::HKLDict)
+
+Returns the set of vectors in an `HKLDict` for which values have been defined.
+"""
+function vectors(hkl::HKLDict)
+    return keys(hkl.dict)
+end
+
+function HKLDict(hkl::HKLData{D,T}) where {D,T<:Union{<:Number,<:AbstractArray{Number}}}
+    dict = Dict{SVector{D,Int},T}()
+    # Get the offset for the indices
+    offset = minimum.(hkl.bounds) .- 1
+    # Iterate through the matrix and get its coordinates
+    for ind in CartesianIndices(hkl.data)
+        # Only add nonzero elements
+        if hkl.data[ind] != zero(T)
+            dict[Tuple(ind) .+ offset] = hkl.data[ind]
+        end
+    end
+    return HKLDict(dict)
+end
+
+function HKLData(hkl::HKLDict{D,T}) where {D,T<:Union{<:Number,<:AbstractArray{Number}}}
+    # Find the bounds
+    bounds = MVector(UnitRange(extrema(v[n] for v in keys(hkl.dict)...)) for n in 1:D)
+    data = zeros(T, length.(bounds)...)
+    # Loop through the dictionary
+    for (k,v) in hkl.dict
+        data[k...] = v
+    end
+    return HKLData(data, bounds)
+end
+
+"""
     ReciprocalWavefunction{D,T<:Real} <: AbstractReciprocalSpaceData{D}
 
 Contains a wavefunction stored by k-points and bands in a planewave basis. Used to store data in

--- a/src/data.jl
+++ b/src/data.jl
@@ -479,18 +479,18 @@ Contains a wavefunction stored by k-points and bands in a planewave basis. Used 
 VASP WAVECAR files. Each k-point is expected to have the same number of bands.
 
 Every band has associated data containing coefficients of the constituent planewaves stored in a 
-`HKLData{D,Complex{T}}`. Unlike most data structures provided by this package, the type of
+`HKLDict{D,Complex{T}}`. Unlike most data structures provided by this package, the type of
 complex number used does not default to `Float64`: wavefunction data is often supplied as a 
 `Complex{Float32}` to reduce the size of the data.
 """
 struct ReciprocalWavefunction{D,T<:Real} <: AbstractReciprocalSpaceData{D}
     # Reciprocal lattice on which the k-points are defined
     rlatt::BasisVectors{D}
-    # Planewave coefficients: a Matrix (size nkpt*maxnband) of HKLData
-    waves::Matrix{HKLData{D,Complex{T}}}
+    # Planewave coefficients: a Matrix (size nkpt*maxnband) of HKLDicts
+    waves::Matrix{HKLDict{D,Complex{T}}}
     function ReciprocalWavefunction{D,T}(
         rlatt::BasisVectors{D},
-        waves::AbstractMatrix{HKLData{D,Complex{T}}}
+        waves::AbstractMatrix{<:AbstractHKL{D,Complex{T}}}
     ) where {D,T<:Real}
         # Checks were removed here
         return new(rlatt, waves)
@@ -499,7 +499,7 @@ end
 
 function ReciprocalWavefunction{D,T}(
     latt::AbstractLattice{D},
-    waves::AbstractMatrix{HKLData{D,Complex{T}}};
+    waves::AbstractMatrix{<:AbstractHKL{D,Complex{T}}};
     prim = true
 ) where {D,T<:Real}
     M = prim ? prim(latt) : conv(latt)

--- a/src/data.jl
+++ b/src/data.jl
@@ -415,7 +415,12 @@ the array. Unspecified elements in an `HKLDict` are assumed to be zero.
 """
 struct HKLDict{D,T} <: AbstractHKL{D,T}
     dict::Dict{SVector{D,Int},T}
+    function HKLDict(dict::AbstractDict{<:SVector{D,Int},<:T}) where {D,T}
+        return new{D,T}(dict)
+    end
 end
+
+HKLDict{D,T}() where {D,T} = HKLDict(Dict{SVector{D,Int},T}())
 
 Base.has_offset_axes(hkl::HKLDict) = true
 

--- a/src/data.jl
+++ b/src/data.jl
@@ -336,7 +336,7 @@ end
 Stores information associated with specific sets of reciprocal lattice vectors. Data can be
 accessed and modified using regular indexing, where indices may be negative.
 """
-struct HKLData{D,T} <: AbstractReciprocalSpaceData{D}
+struct HKLData{D,T} <: AbstractHKL{D,T}
     # the actual data
     data::Array{T,D}
     # the bounds in each dimension
@@ -413,7 +413,7 @@ a large number of zero components. For wavefunction data, which is often specifi
 cutoff that corresponds to a distance in reciprocal space, there are many zero valued elements to
 the array. Unspecified elements in an `HKLDict` are assumed to be zero.
 """
-struct HKLDict{D,T} <: AbstractReciprocalSpaceData{D}
+struct HKLDict{D,T} <: AbstractHKL{D,T}
     dict::Dict{SVector{D,Int},T}
 end
 

--- a/src/software/abinit.jl
+++ b/src/software/abinit.jl
@@ -752,6 +752,7 @@ function read_abinit_wavefunction(io::IO)
         "hklbounds: ", hklbounds, "\n",
         "Calculated from ecut = ", header.ecut, " Hartree"
     )
+    # Maximum number of bands in a k-point
     nb = maximum(header.nband)
     # Eigenvalue and occupancy matrices
     # Not returned (yet) but will be stored anyway
@@ -762,9 +763,7 @@ function read_abinit_wavefunction(io::IO)
     # Loop over all the spin polarizations
     for sppol in 1:header.nsppol
         # Start with a new wave matrix
-        waves = [
-            zeros(HKLData{3,Complex{Float64}}, hklbounds...) for kp in 1:header.nkpt, b in 1:nb
-        ]
+        waves = [HKLDict{3,Complex{Float64}}() for k in 1:header.nkpt, b in 1:nb]
         # Loop over all the k-points
         for kpt in 1:header.nkpt
             # Skip over record length

--- a/src/software/vasp.jl
+++ b/src/software/vasp.jl
@@ -52,7 +52,7 @@ function readWAVECAR(io::IO)
     # Plane wave coefficients
     # Vector (size nkpt) of vectors (size nband) of vectors (size npw) of ComplexF32
     # so planewave coeffs per band per k-point - that is a *lot* of data
-    waves = [zeros(HKLData{3,Complex{Float32}}, hklbounds...) for kp in 1:nkpt, b in 1:nband]
+    waves = [HKLDict{3,Complex{Float32}}() for kp in 1:nkpt, b in 1:nband]
     # Loop through the spins
     for s in 1:nspin
         # Loop through the k-points

--- a/src/types.jl
+++ b/src/types.jl
@@ -61,6 +61,14 @@ abstract type AbstractReciprocalSpaceData{D} <: AbstractCrystalData{D}
 end
 
 """
+    AbstractReciprocalSpaceData{D}
+
+Supertype for crystal data stored by HKL index.
+"""
+abstract type AbstractHKL{D,T} <: AbstractReciprocalSpaceData{D}
+end
+
+"""
     AbstractDensityOfStates
 
 Supertype for all density of states data.


### PR DESCRIPTION
In the future I intend to use this so that I can reduce the size of large `HKLData` objects, such as the matrix of them used in `ReciprocalWavefunction`.