### PR TITLE
Big documentation update

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ feature, then push the branch and open a pull request on Github.
 
 All merging should be done through a rebase operation. This is simpler than using a standard merge,
 as it maintains a linear commit history. However, you will have to ensure that you have fetched or
-pulled from the origin repo to avoid serious merge conflicts.
+pulled from the origin repo and rebased on the parent branch to avoid serious merge conflicts.
 
 ## Testing and continuous integrations
 
@@ -22,8 +22,8 @@ to use `Documenter` to generate documentation from docstrings in the near future
 
 ### Julia version
 
-CrystalStructures.jl is being written for Julia 1.6, which is an LTS release. This may change in
-the future, but for now, avoid using any features that are present in later releases of Julia.
+Xtal.jl is being written for Julia 1.6, which is an LTS release. This may change in the future, but
+for now, avoid using any features that are present in later releases of Julia.
 
 ### Dependencies and interoperability
 
@@ -42,7 +42,7 @@ When in doubt, follow the Julia style guide, located here: https://docs.julialan
 
 ### Exceptions to the Julia style guide
 
-For `ABINITHeader` structs, direct field access may be used to assign and retrieve values.
+For `Xtal.ABINITHeader` structs, direct field access may be used to assign and retrieve values.
 
 Avoid using short-circuit `if` statements - write them out explicitly. There are many instances of 
 short-circuited `if` statements throughout the code at this point, and you are welcome to restore 
@@ -53,7 +53,11 @@ them to full `if` statements.
 Keep lines under 100 characters in all files. You can use string concatenation, among other tools,
 to split long strings if they come up. If a line is really long, consider whether you can simplify
 the line by reducing the amount of nesting, shortening variable names, or splitting operations into
-multiple lines.
+multiple lines. The general strategy that has been used is calling `string()`, which can stringify
+a variety of arguments and pass through literals.
+
+We have found that some methods of splitting strings may not be compatible with Julia 1.6 - please
+make sure to test this before pushing.
 
 ### Naming
 
@@ -63,12 +67,14 @@ and functions.
 ### Comments and documentation
 
 All functions and structs must have an associated docstring explaining the purpose of the code, 
-*even if the struct or method is not exported.*
+*even if the struct or method is not exported.* For internal methods and structs, please prefix
+them with the module name in the docstring.
 
 It's better to be verbose about what's going on with your code. Even if a remark seems obvious, 
 feel free to leave it in.
 
-Comments are generally placed above the lines that they refer to.
+Comments are generally placed above the lines that they refer to. Inline comments are fine, this is
+just the pattern that's been used consistently in the code.
 
 ### Type parameters of newly defined types
 
@@ -88,7 +94,7 @@ static arrays allow for higher performance.
 
 The use of static arrays is encouraged whenever the array dimensionality is unlikely to change
 (and in principle could be used as a type parameter). This universally applies to real space and
-reciprocal space vectors, since their dimensionality is fixed.
+reciprocal space vectors, since their dimensionality is fixed (and usually 3).
 
 The type `AtomList{D}` provides a great example of static vs. dynamic vector usage. The type 
 contains a `Vector{AtomPosition{D}}`, which is dynamic because the number of atoms in a crystal
@@ -110,9 +116,6 @@ If you need to use an `SMatrix{D1,D2,T,L}` in a struct, be sure that you can def
 `D1` and `D2`. Otherwise, it might be a better idea to store the data internally as an
 `SVector{D,SVector{D,T}}`, and define `convert()` for it to turn it into a matrix.
 
-In the future, we may consider using the `ComputedFieldTypes` package, or integrating any new Julia
-functionality in future versions.
-
 ### Logging and printing
 
 Feel free to leave `@debug` statements in any code you include. Unless the logging level is set to 
@@ -124,7 +127,8 @@ julia> ENV["JULIA_DEBUG"] = Xtal
 ```
 
 Try to minimize the use of repeated `@info`, `@warn`, or `@error` statements in loops. Printing to
-the terminal can bottleneck functions.
+the terminal can bottleneck functions. `@debug` statements will normally be skipped unless a logger
+explicitly compiles them or `$JULIA_DEBUG` is set for the module.
 
 Avoid using `println()` if one of the logging macros better suits the purpose. If `println()` is
 used, consider whether it might be a better idea to print to `stderr` instead of `stdout`. Note 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,7 @@ reciprocal space vectors, since their dimensionality is fixed (and usually 3).
 The type `AtomList{D}` provides a great example of static vs. dynamic vector usage. The type 
 contains a `Vector{AtomPosition{D}}`, which is dynamic because the number of atoms in a crystal
 (either the generating set or the visual template) may vary greatly. However, the type 
-`AtomPostion{D}` contains a field for the atomic position vector, which is an `SVector{D,Float64}`
+`AtomPosition{D}` contains a field for the atomic position vector, which is an `SVector{D,Float64}`
 since atomic positions are not expected to vary in dimensionality.
 
 The `StaticArrays` package provides the `SArray` type, which is immutable (cannot be altered after

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You can access package mode by typing `]` at the REPL.
 ## Current features
 
 * Reading of common file formats:
-     + ABINIT potential and density outputs from versions 7.10.5 and 8.10.4
+     + ABINIT potential, density, and wavefunction outputs from versions 7.10.5 and 8.10.4
      + ABINIT HGH pseudopotentials
      + VASP WAVECAR, DOSCAR, and PROCAR
      + XCrysDen XSF
@@ -24,19 +24,20 @@ You can access package mode by typing `]` at the REPL.
      + CPpackage2 outputs
 * Writing of common file formats:
      + XCrysDen XSF
+* Operations on datagrids:
+     + Addition, subtraction, multiplication
+     + FFTs on real space data grids
 
 ## Planned features
 
 This project is just starting to get off the ground, but here's what we have planned:
 
  * Reading and writing of common file formats:
-     + ABINIT wavefunction outputs
      + XYZ files
      + XTL files
      + CIF files
  * Manipulation of data grids associated with crystal structures
-     + Common elementwise mathematical operations on data grids
-     + Grid reinterpolation
+     + Real space grid reinterpolation
      
 ...and more that we will decide in time! If you'd like to contibute, be sure to read the included
 contributing guidelines.

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ You can access package mode by typing `]` at the REPL.
 ## Current features
 
 * Reading of common file formats:
-     + ABINIT potential, density, and wavefunction outputs from versions 7.10.5 and 8.10.4
-     + ABINIT HGH pseudopotentials
+     + abinit potential, density, and wavefunction outputs from versions 7.10.5 and 8.10.4
+     + abinit HGH pseudopotentials
      + VASP WAVECAR, DOSCAR, and PROCAR
      + XCrysDen XSF
      + XYZ files

--- a/src/Xtal.jl
+++ b/src/Xtal.jl
@@ -50,7 +50,7 @@ const REDUCTION_MATRIX_3D =
 )
 
 """
-    TOL_DEF
+    Xtal.TOL_DEF
 
 Default tolerance for discrepancies in floating point values.
 """
@@ -81,14 +81,14 @@ const CVASP = 0.262465831
 # the correct value is actually 0.26246842360751754
 
 """
-    _allsame(itr)
+    Xtal._allsame(itr)
 
 Returns `true` if all the elements of an iterator are identical.
 """
 _allsame(itr) = all(x -> x == first(itr), itr)
 
 """
-    _selfdot(v)
+    Xtal._selfdot(v)
 
 Computes the dot product of a vector with itself.
 """

--- a/src/data.jl
+++ b/src/data.jl
@@ -1,3 +1,6 @@
+# REAL SPACE
+#-------------------------------------------------------------------------------------------------#
+
 """
     RealSpaceDataGrid{D,T} <: AbstractRealSpaceData{D}
 
@@ -212,6 +215,9 @@ function interpolate(g::RealSpaceDataGrid, r::AbstractVector{<:Real})
     inds = reduced .* size
 end
 =#
+
+# RECIPROCAL SPACE
+#-------------------------------------------------------------------------------------------------#
 
 """
     KPointGrid{D} <: AbstractKPoints{D}
@@ -473,6 +479,9 @@ Base.getindex(wf::ReciprocalWavefunction{D,T}, inds...) where {D,T} = wf.waves[i
 nkpt(wf::ReciprocalWavefunction{D,T}) where {D,T} = size(wf.waves, 1)
 nband(wf::ReciprocalWavefunction{D,T}) where {D,T} = size(wf.waves, 2)
 
+# DENSITY OF STATES
+#-------------------------------------------------------------------------------------------------#
+
 """
     DensityOfStates
 
@@ -626,6 +635,9 @@ function nelectrons(d::DensityOfStates)
     b = i1 - m*e1
     return m*fermi(d) + b
 end
+
+# ATOMIC DATA
+#-------------------------------------------------------------------------------------------------#
 
 """
     AtomicData{D,T}

--- a/src/data.jl
+++ b/src/data.jl
@@ -106,7 +106,7 @@ By default, units are assumed to be cubic angstroms.
 voxelsize(g::RealSpaceDataGrid) = volume(g) / prod(gridsize(g))
 
 """
-    grid_check(g1::RealSpaceDataGrid, g2::RealSpaceDataGrid)
+    Xtal.grid_check(g1::RealSpaceDataGrid, g2::RealSpaceDataGrid)
 
 Performs a check on two `RealSpaceDataGrid`s to ensure that the basis, origin shift, and grid
 dimensions are the same before performing mathematical operations.
@@ -387,7 +387,7 @@ end
 Base.has_offset_axes(g::HKLData) = true
 
 """
-    shiftbounds(g::HKLData{D,T}, inds) -> NTuple{D,<:Integer}
+    Xtal.shiftbounds(g::HKLData{D,T}, inds) -> NTuple{D,<:Integer}
 
 Checks that integer array indices used to access data in an `HKLData` are valid and shifts them to 
 access the correct portions of the backing array.
@@ -669,7 +669,7 @@ SphericalComponents(v::SVector{N,<:Real}) where N = SphericalComponents(v...)
 SphericalComponents(t::NTuple{N,<:Real}) where N = SphericalComponents(t...)
 
 """
-    sc_ind(l::Integer, m::Integer) -> Int
+    Xtal.sc_ind(l::Integer, m::Integer) -> Int
 
 Gets the associated linear index for a pair of (l,m) values used in `SphericalComponents`.
 """

--- a/src/lattices.jl
+++ b/src/lattices.jl
@@ -1,5 +1,5 @@
 """
-    lattice_sanity_check(M::AbstractMatrix)
+    Xtal.lattice_sanity_check(M::AbstractMatrix)
 
 Runs checks on a matrix intended to represent basis vectors of a crystal unit cell. Returns
 nothing, but warns if the cell vectors form a left-handed coordinate system, and throws an 
@@ -215,7 +215,7 @@ end
 =#
 
 """
-    lattice_pair_generator_3D(M::AbstractMatrix; prim=false, ctr=:P)
+    Xtal.lattice_pair_generator_3D(M::AbstractMatrix; prim=false, ctr=:P)
 
 Generates a pair of 3D lattices that are related by common crystallographic transformations.
 
@@ -297,7 +297,7 @@ conventional cell volume may be calculated with `primitive=false`.
 volume(l::AbstractLattice; primitive::Bool=true) = volume(primitive ? prim(l) : conv(l))
 
 """
-    generate_pairs(D::Integer) -> Vector{NTuple{2,Int}}
+    Xtal.generate_pairs(D::Integer) -> Vector{NTuple{2,Int}}
 
 Generate pairs of integers up to `D` in ascending order.
 """
@@ -314,7 +314,7 @@ function generate_pairs(D::Integer)
 end
 
 """
-    generate_pairs(::Type{Val{D}}) -> SVector{D*(D-1)/2, NTuple{2,Int}}
+    Xtal.generate_pairs(::Type{Val{D}}) -> SVector{D*(D-1)/2, NTuple{2,Int}}
 
 Generate pairs of integers up to `D` in ascending order in an `SVector`.
 """
@@ -427,7 +427,7 @@ end
 maxHKLindex(b::BasisVectors{3}, ecut::Real; c = CVASP) = maxHKLindex(matrix(b), ecut, c = c)
 
 """
-    maxHKLindex(L::AbstractLattice, ecut::Real; prim=true, c = CVASP)
+    Xtal.maxHKLindex(L::AbstractLattice, ecut::Real; prim=true, c = CVASP)
 
 Determines the maximum integer values of the reciprocal lattice vectors needed to store data out
 to a specific energy cutoff for a 3D lattice.

--- a/src/software/abinit.jl
+++ b/src/software/abinit.jl
@@ -1,5 +1,5 @@
 """
-    ABINITPseudopotentialInfo
+    Xtal.ABINITPseudopotentialInfo
 
 Information about a pseudopotential used in an ABINIT calculation.
 """
@@ -25,7 +25,7 @@ end
 # Making this thing mutable is probably the best idea here
 # That way we can initialize the struct and then update all the data
 """
-    ABINITHeader
+    Xtal.ABINITHeader
 
 Header information from an abinit FORTRAN binary output file.
 
@@ -163,7 +163,7 @@ Base.getindex(h::ABINITHeader, name::Symbol) = getfield(h, name)
 Base.setindex!(x, h::ABINITHeader, name::Symbol) = setfield!(x, h, name)
 
 """
-    symrel_to_sg(symrel::AbstractVector{<:AbstractMatrix{<:Integer}}) -> Int
+    Xtal.symrel_to_sg(symrel::AbstractVector{<:AbstractMatrix{<:Integer}}) -> Int
 
 Converts a list of ABINIT symmetry operations to the corresponding space group number and setting.
 """
@@ -207,7 +207,7 @@ function triang_index(n)
 end
 
 """
-    get_abinit_version(io::IO) -> NamedTuple{}
+    Xtal.get_abinit_version(io::IO) -> NamedTuple{}
 
 Gets the ABINIT version information from a calculation output header.
 """
@@ -223,7 +223,7 @@ function get_abinit_version(io::IO)
 end
 
 """
-    read_abinit_header_57(io::IO) -> ABINITHeader
+    Xtal.read_abinit_header_57(io::IO) -> ABINITHeader
 
 Reads in an abinit header from the outputs of calculations made by versions up to 7.10. These files
 will contain a `headform` value of 57.
@@ -384,7 +384,7 @@ function read_abinit_header_57(io::IO)
 end
 
 """
-    read_abinit_header_80(io::IO) -> ABINITHeader
+    Xtal.read_abinit_header_80(io::IO) -> ABINITHeader
 
 Reads in an abinit header from the outputs of calculations made by versions up to 8.10. These files
 will contain a `headform` value of 80.
@@ -575,7 +575,7 @@ function read_abinit_header_80(io::IO)
 end
 
 """
-    read_abinit_header(io::IO)
+    Xtal.read_abinit_header(io::IO)
 
 Reads the header of an ABINIT output file, automatically determining the format of the header
 from the first few digits.
@@ -607,12 +607,11 @@ function read_abinit_header(io::IO)
 end
 
 """
-    function read_abinit_datagrids(T, io, nspden, ngfft) -> Vector{Matrix{T}}
+    Xtal.read_abinit_datagrids(T, io, nspden, ngfft) -> Vector{Matrix{T}}
 
 Reads the datagrid portion of an abinit density output, following the header. 
 
-Electron density values are given in electrons/Bohr³ in the abinit output files. These are 
-converted to electrons/Å³ in the resulting grids.
+Electron density values are given in electrons/Bohr³ in the abinit output files.
 
 Depending on the value of `cplex` from the header, the resulting matrix may either contain
 `Float64` or `Complex{Float64}` data.

--- a/src/vectors.jl
+++ b/src/vectors.jl
@@ -1,6 +1,6 @@
 """
-    _is_linearly_independent(vecs::AbstractMatrix{<:Number}) -> Bool
-    _is_linearly_independent(vecs::AbstractVector{<:Number}...) -> Bool
+    Xtal._is_linearly_independent(vecs::AbstractMatrix{<:Number}) -> Bool
+    Xtal._is_linearly_independent(vecs::AbstractVector{<:Number}...) -> Bool
 
 Determines whether a set of vectors is linearly independent.
 


### PR DESCRIPTION
Both the README and CONTRIBUTING documents have changed, as well as the format of many docstrings. In particular, unexported objects should always be prefixed with `Xtal.` in their docstrings. If you spot any cases where this was not done (or done incorrectly), feel free to push changes to this branch.