### PR TITLE
`HKLDict` type for reciprocal space data that would be poorly represented in an array

### DIFF
--- a/src/Xtal.jl
+++ b/src/Xtal.jl
@@ -99,8 +99,8 @@ include("vectors.jl")
 # Abstract types used in type tree
 include("types.jl")
 export AbstractLattice, AbstractCrystal, AbstractCrystalData, AbstractRealSpaceData, 
-       AbstractReciprocalSpaceData, AbstractKPoints, AbstractDensityOfStates, AbstractPotential,
-       AbstractPseudopotential
+       AbstractReciprocalSpaceData, AbstractHKL, AbstractKPoints, AbstractDensityOfStates,
+       AbstractPotential, AbstractPseudopotential
 # Methods and structs for working with crystal lattices
 include("lattices.jl")
 export BasisVectors, RealLattice, ReciprocalLattice
@@ -116,7 +116,7 @@ export Crystal, CrystalWithDatasets
 export natom_template, data, prim, conv, volume
 # Methods and structs for working with different types of data associated with crystals
 include("data.jl")
-export RealSpaceDataGrid, KPointGrid, KPointList, BandAtKPoint, BandStructure, HKLData,
+export RealSpaceDataGrid, KPointGrid, KPointList, BandAtKPoint, BandStructure, HKLData, HKLDict,
        ReciprocalWavefunction, DensityOfStates, ProjectedDensityOfStates, FatBands, AtomicData,
        SphericalComponents
 export grid, gridsize, volume, voxelsize, integrate, fft, nkpt, nband, bounds, fermi, smear,

--- a/src/data.jl
+++ b/src/data.jl
@@ -535,18 +535,18 @@ Contains a wavefunction stored by k-points and bands in a planewave basis. Used 
 VASP WAVECAR files. Each k-point is expected to have the same number of bands.
 
 Every band has associated data containing coefficients of the constituent planewaves stored in a 
-`HKLData{D,Complex{T}}`. Unlike most data structures provided by this package, the type of
+`HKLDict{D,Complex{T}}`. Unlike most data structures provided by this package, the type of
 complex number used does not default to `Float64`: wavefunction data is often supplied as a 
 `Complex{Float32}` to reduce the size of the data.
 """
 struct ReciprocalWavefunction{D,T<:Real} <: AbstractReciprocalSpaceData{D}
     # Reciprocal lattice on which the k-points are defined
     rlatt::BasisVectors{D}
-    # Planewave coefficients: a Matrix (size nkpt*maxnband) of HKLData
-    waves::Matrix{HKLData{D,Complex{T}}}
+    # Planewave coefficients: a Matrix (size nkpt*maxnband) of HKLDicts
+    waves::Matrix{HKLDict{D,Complex{T}}}
     function ReciprocalWavefunction{D,T}(
         rlatt::BasisVectors{D},
-        waves::AbstractMatrix{HKLData{D,Complex{T}}}
+        waves::AbstractMatrix{<:AbstractHKL{D,Complex{T}}}
     ) where {D,T<:Real}
         # Checks were removed here
         return new(rlatt, waves)
@@ -555,7 +555,7 @@ end
 
 function ReciprocalWavefunction{D,T}(
     latt::AbstractLattice{D},
-    waves::AbstractMatrix{HKLData{D,Complex{T}}};
+    waves::AbstractMatrix{<:AbstractHKL{D,Complex{T}}};
     prim = true
 ) where {D,T<:Real}
     M = prim ? prim(latt) : conv(latt)

--- a/src/data.jl
+++ b/src/data.jl
@@ -373,7 +373,7 @@ end
 Stores information associated with specific sets of reciprocal lattice vectors. Data can be
 accessed and modified using regular indexing, where indices may be negative.
 """
-struct HKLData{D,T} <: AbstractReciprocalSpaceData{D}
+struct HKLData{D,T} <: AbstractHKL{D,T}
     # the actual data
     data::Array{T,D}
     # the bounds in each dimension
@@ -469,7 +469,7 @@ a large number of zero components. For wavefunction data, which is often specifi
 cutoff that corresponds to a distance in reciprocal space, there are many zero valued elements to
 the array. Unspecified elements in an `HKLDict` are assumed to be zero.
 """
-struct HKLDict{D,T} <: AbstractReciprocalSpaceData{D}
+struct HKLDict{D,T} <: AbstractHKL{D,T}
     dict::Dict{SVector{D,Int},T}
 end
 

--- a/src/data.jl
+++ b/src/data.jl
@@ -471,7 +471,12 @@ the array. Unspecified elements in an `HKLDict` are assumed to be zero.
 """
 struct HKLDict{D,T} <: AbstractHKL{D,T}
     dict::Dict{SVector{D,Int},T}
+    function HKLDict(dict::AbstractDict{<:SVector{D,Int},<:T}) where {D,T}
+        return new{D,T}(dict)
+    end
 end
+
+HKLDict{D,T}() where {D,T} = HKLDict(Dict{SVector{D,Int},T}())
 
 Base.has_offset_axes(hkl::HKLDict) = true
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -61,6 +61,14 @@ abstract type AbstractReciprocalSpaceData{D} <: AbstractCrystalData{D}
 end
 
 """
+    AbstractReciprocalSpaceData{D}
+
+Supertype for crystal data stored by HKL index.
+"""
+abstract type AbstractHKL{D,T} <: AbstractReciprocalSpaceData{D}
+end
+
+"""
     AbstractDensityOfStates
 
 Supertype for all density of states data.


### PR DESCRIPTION
I'm wondering whether we might be better served by a sparse array implementation here, so I don't know if this PR is a good idea, but I'm creating it just in case someone else is interested in something like this.

I tried using an `HKLDict` to replace `HKLData` in `ReciprocalWavefunction`, but this made the memory usage situation far worse, so there's no need to merge this for any performance reasons.