### PR TITLE
Fixed `readPROCAR()` to use updated `FatBands` constructor

### DIFF
--- a/src/software/vasp.jl
+++ b/src/software/vasp.jl
@@ -215,7 +215,7 @@ function readPROCAR(io::IO)
                     ln = readline(io)
                     re = parse.(Float64, split(ln)[2:10])
                     ln = readline(io)
-                    phase[:,k,j,i] = a + re + parse.(Float64, split(ln)[2:10]) * im
+                    phase[:,k,j,i] = re + parse.(Float64, split(ln)[2:10]) * im
                 end
             end
         end

--- a/src/software/vasp.jl
+++ b/src/software/vasp.jl
@@ -191,8 +191,7 @@ function readPROCAR(io::IO)
     # occupancies = Matrix{Float64}(undef, nkpt, nband)
     energies = zeros(Float64, nkpt, nband)
     projband = zeros(Float64, 9, nion, nband, nkpt)
-    phase_real = zeros(Float64, 9, nion, nband, nkpt)
-    phase_imag = zeros(Float64, 9, nion, nband, nkpt)
+    phase = zeros(Complex{Float64}, 9, nion, nband, nkpt)
     # Begins loop
     for i in 1:nkpt
         readuntil(io, "k-point")
@@ -214,9 +213,9 @@ function readPROCAR(io::IO)
                 readline(io)
                 for k in 1:nion
                     ln = readline(io)
-                    phase_real[:,k,j,i] = parse.(Float64, split(ln)[2:10])
+                    re = parse.(Float64, split(ln)[2:10])
                     ln = readline(io)
-                    phase_imag[:,k,j,i] = parse.(Float64, split(ln)[2:10])
+                    phase[:,k,j,i] = a + re + parse.(Float64, split(ln)[2:10]) * im
                 end
             end
         end
@@ -226,8 +225,7 @@ function readPROCAR(io::IO)
     return FatBands{3}(
         energies,
         projband,
-        phase_real,
-        phase_imag,
+        phase
     )
 end
 


### PR DESCRIPTION
This should in principle fix #57 but I'll have @xamberl review this change (I don't have any PROCAR files to test on yet)