### PR TITLE
Numerous fixes for lattice constructors

### DIFF
--- a/src/filetypes.jl
+++ b/src/filetypes.jl
@@ -188,7 +188,7 @@ function readXSF3D(
         conv = BasisVectors{3}(REDUCTION_MATRIX_3D[ctr] \ matrix(prim))
     end
     # Generate the real space lattice
-    latt = RealLattice{3}(prim, conv)
+    latt = RealLattice(prim, conv)
     xtal = Crystal{3}(latt, spgrp, origin, atom_list, atom_list)
     return CrystalWithDatasets{3,String,RealSpaceDataGrid{3}}(xtal, data)
 end

--- a/src/filetypes.jl
+++ b/src/filetypes.jl
@@ -185,7 +185,7 @@ function readXSF3D(
     end
     # If the conventional cell hasn't been defined, generate it
     if iszero(conv)
-        conv = BasisVectors{3}(REDUCTION_MATRIX_3D[ctr] \ matrix(prim))
+        conv = BasisVectors{3}(matrix(prim) / REDUCTION_MATRIX_3D[ctr])
     end
     # Generate the real space lattice
     latt = RealLattice(prim, conv)

--- a/src/lattices.jl
+++ b/src/lattices.jl
@@ -209,8 +209,8 @@ function RealLattice(latt::ReciprocalLattice)
     return RealLattice(dual(prim(latt))/2π, dual(conv(latt))/2π)
 end
 
-Base.convert(::Type{RealLattice}, latt::AbstractLattice) = RealLattice(latt)
-Base.convert(::Type{ReciprocalLattice}, latt::AbstractLattice) = ReciprocalLattice(latt)
+Base.convert(::Type{<:RealLattice}, latt::AbstractLattice) = RealLattice(latt)
+Base.convert(::Type{<:ReciprocalLattice}, latt::AbstractLattice) = ReciprocalLattice(latt)
 #=
 function convert(::Type{RealLattice{D}}, latt::AbstractLattice{D}) where D
     return RealLattice(latt)

--- a/src/lattices.jl
+++ b/src/lattices.jl
@@ -158,7 +158,7 @@ function (::Type{T})(
     b::BasisVectors{D},
     transform::AbstractMatrix=diagm(ones(D))
 ) where {D,T<:AbstractLattice}
-    return T(b, BasisVectors{D}(transform*b))
+    return T(b, BasisVectors{D}(b*transform))
 end
 
 # Get primitive and conventional lattices

--- a/src/lattices.jl
+++ b/src/lattices.jl
@@ -256,7 +256,7 @@ By default, inputs are assumed to describe a conventional cell.
 """
 =#
 function RealLattice{3}(M::AbstractMatrix{<:Real}; prim=false, ctr=:P)
-    return RealLattice{3}(lattice_pair_generator_3D(M, prim=prim, ctr=ctr)...)
+    return RealLattice(lattice_pair_generator_3D(M, prim=prim, ctr=ctr)...)
 end
 
 """

--- a/src/lattices.jl
+++ b/src/lattices.jl
@@ -197,7 +197,7 @@ ReciprocalLattice(latt::ReciprocalLattice) = latt
 Converts a real lattice to its corresponding reciprocal lattice.
 """
 function ReciprocalLattice(latt::RealLattice)
-    return ReciprocalLattice(dual(prim(latt))*2π, dual(conv(latt)*2π))
+    return ReciprocalLattice(dual(prim(latt))*2π, dual(conv(latt))*2π)
 end
 
 """
@@ -206,7 +206,7 @@ end
 Converts a reciprocal lattice to its corresponding real lattice.
 """
 function RealLattice(latt::ReciprocalLattice)
-    return RealLattice(dual(prim(latt))/2π, dual(conv(latt)/2π))
+    return RealLattice(dual(prim(latt))/2π, dual(conv(latt))/2π)
 end
 
 Base.convert(::Type{RealLattice}, latt::AbstractLattice) = RealLattice(latt)


### PR DESCRIPTION
I've found that there were a lot of broken constructors and unnecessary type parameters included for `RealLattice` and `ReciprocalLattice`. This should clear a lot of that up, and I've updated `readXSF3D()` and various methods for reading abinit outputs to handle the change in constructors.