### PR TITLE
Created `HKLDict` struct (dictionary storage for reciprocal space data)

### DIFF
--- a/src/Xtal.jl
+++ b/src/Xtal.jl
@@ -99,8 +99,8 @@ include("vectors.jl")
 # Abstract types used in type tree
 include("types.jl")
 export AbstractLattice, AbstractCrystal, AbstractCrystalData, AbstractRealSpaceData, 
-       AbstractReciprocalSpaceData, AbstractKPoints, AbstractDensityOfStates, AbstractPotential,
-       AbstractPseudopotential
+       AbstractReciprocalSpaceData, AbstractHKL, AbstractKPoints, AbstractDensityOfStates,
+       AbstractPotential, AbstractPseudopotential
 # Methods and structs for working with crystal lattices
 include("lattices.jl")
 export BasisVectors, RealLattice, ReciprocalLattice
@@ -116,7 +116,7 @@ export Crystal, CrystalWithDatasets
 export natom_template, data, prim, conv, volume
 # Methods and structs for working with different types of data associated with crystals
 include("data.jl")
-export RealSpaceDataGrid, KPointGrid, KPointList, BandAtKPoint, BandStructure, HKLData,
+export RealSpaceDataGrid, KPointGrid, KPointList, BandAtKPoint, BandStructure, HKLData, HKLDict,
        ReciprocalWavefunction, DensityOfStates, ProjectedDensityOfStates, FatBands, AtomicData,
        SphericalComponents
 export grid, gridsize, volume, voxelsize, integrate, fft, nkpt, nband, bounds, fermi, smear,

--- a/src/data.jl
+++ b/src/data.jl
@@ -491,6 +491,75 @@ Base.abs(hkl::HKLData) = HKLData(abs.(grid(hkl)), bounds(hkl))
 Base.abs2(hkl::HKLData) = HKLData(abs2.(grid(hkl)), bounds(hkl))
 
 """
+    HKLDict{D,T}
+
+An alternative to `HKLData` uses a dictionary instead of an array as a backing field.
+
+This is a more space-efficient alternative to `HKLData` in the case of reciprocal space data with
+a large number of zero components. For wavefunction data, which is often specified to some energy
+cutoff that corresponds to a distance in reciprocal space, there are many zero valued elements to
+the array. Unspecified elements in an `HKLDict` are assumed to be zero.
+"""
+struct HKLDict{D,T} <: AbstractReciprocalSpaceData{D}
+    dict::Dict{SVector{D,Int},T}
+end
+
+Base.has_offset_axes(hkl::HKLDict) = true
+
+function Base.getindex(hkl::HKLDict{D,T}, inds...) where {D,T}
+    v = SVector{D,Int}(inds...)
+    if haskey(hkl.dict, v)
+        return hkl.dict[v]
+    else
+        # Return a zero element of some kind by default
+        return zero(T)
+    end
+end
+
+function Base.setindex!(hkl::HKLDict{D,T}, value::T, inds...) where {D,T}
+    hkl.dict[SVector{D,Int}(inds...)] = value
+end
+
+Base.keys(hkl::HKLDict) = keys(hkl.dict)
+
+Base.iterate(hkl::HKLDict) = iterate(hkl.dict)
+Base.iterate(hkl::HKLDict, i) = iterate(hkl.dict, i)
+
+"""
+    vectors(hkl::HKLDict)
+
+Returns the set of vectors in an `HKLDict` for which values have been defined.
+"""
+function vectors(hkl::HKLDict)
+    return keys(hkl.dict)
+end
+
+function HKLDict(hkl::HKLData{D,T}) where {D,T<:Union{<:Number,<:AbstractArray{Number}}}
+    dict = Dict{SVector{D,Int},T}()
+    # Get the offset for the indices
+    offset = minimum.(hkl.bounds) .- 1
+    # Iterate through the matrix and get its coordinates
+    for ind in CartesianIndices(hkl.data)
+        # Only add nonzero elements
+        if hkl.data[ind] != zero(T)
+            dict[Tuple(ind) .+ offset] = hkl.data[ind]
+        end
+    end
+    return HKLDict(dict)
+end
+
+function HKLData(hkl::HKLDict{D,T}) where {D,T<:Union{<:Number,<:AbstractArray{Number}}}
+    # Find the bounds
+    bounds = MVector(UnitRange(extrema(v[n] for v in keys(hkl.dict)...)) for n in 1:D)
+    data = zeros(T, length.(bounds)...)
+    # Loop through the dictionary
+    for (k,v) in hkl.dict
+        data[k...] = v
+    end
+    return HKLData(data, bounds)
+end
+
+"""
     ReciprocalWavefunction{D,T<:Real} <: AbstractReciprocalSpaceData{D}
 
 Contains a wavefunction stored by k-points and bands in a planewave basis. Used to store data in

--- a/src/data.jl
+++ b/src/data.jl
@@ -404,7 +404,7 @@ end
 Stores information associated with specific sets of reciprocal lattice vectors. Data can be
 accessed and modified using regular indexing, where indices may be negative.
 """
-struct HKLData{D,T} <: AbstractReciprocalSpaceData{D}
+struct HKLData{D,T} <: AbstractHKL{D,T}
     # the actual data
     data::Array{T,D}
     # the bounds in each dimension
@@ -500,7 +500,7 @@ a large number of zero components. For wavefunction data, which is often specifi
 cutoff that corresponds to a distance in reciprocal space, there are many zero valued elements to
 the array. Unspecified elements in an `HKLDict` are assumed to be zero.
 """
-struct HKLDict{D,T} <: AbstractReciprocalSpaceData{D}
+struct HKLDict{D,T} <: AbstractHKL{D,T}
     dict::Dict{SVector{D,Int},T}
 end
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -61,6 +61,14 @@ abstract type AbstractReciprocalSpaceData{D} <: AbstractCrystalData{D}
 end
 
 """
+    AbstractReciprocalSpaceData{D}
+
+Supertype for crystal data stored by HKL index.
+"""
+abstract type AbstractHKL{D,T} <: AbstractReciprocalSpaceData{D}
+end
+
+"""
     AbstractDensityOfStates
 
 Supertype for all density of states data.

--- a/src/types.jl
+++ b/src/types.jl
@@ -61,7 +61,7 @@ abstract type AbstractReciprocalSpaceData{D} <: AbstractCrystalData{D}
 end
 
 """
-    AbstractReciprocalSpaceData{D}
+    AbstractHKL{D}
 
 Supertype for crystal data stored by HKL index.
 """


### PR DESCRIPTION
I made this happen earlier (#54) but found that it would actually make the wavefunction file storage problem much worse. I'm suggesting that this feature be merged but without any changes to `ReciprocalWavefunction`.