### PR TITLE
Removal of more unnecessary type parameters (for `AtomPosition`, `AtomList`, and `Crystal`)

### DIFF
--- a/src/atoms.jl
+++ b/src/atoms.jl
@@ -13,23 +13,37 @@ struct AtomPosition{D} <: AbstractRealSpaceData{D}
     name::String
     num::Int
     pos::SVector{D,Float64}
-    function AtomPosition{D}(
+    function AtomPosition(
         name::AbstractString,
         num::Integer,
-        pos::AbstractVector{<:Real}
+        pos::SVector{D,<:Real}
     ) where D
-        # Don't allow empty names by default
+        # Don't allow empty names when an atomic number is passed.
         name = isempty(name) && num > 0 ? ELEMENTS[num] : name
         return new{D}(name, num, pos)
     end
 end
 
-function AtomPosition{D}(num::Integer, pos::AbstractVector{<:Real}) where D
-    return AtomPosition{D}(ELEMENTS[num], num, pos)
+function AtomPosition(name::AbstractString, pos::SVector{D,<:Real}) where D
+    return AtomPosition(name, get(ELEMENT_LOOKUP, name, 0), pos)
+end
+
+function AtomPosition(num::Integer, pos::SVector{D,<:Real}) where D
+    return AtomPosition(ELEMENTS[num], num, pos)
+end
+
+# The methods below require a type parameter in the constructor
+
+function AtomPosition{D}(name::AbstractString, num::Integer, pos::AbstractVector{<:Real}) where D
+    return AtomPosition(name, num, SVector{D,Float64}(pos))
 end
 
 function AtomPosition{D}(name::AbstractString, pos::AbstractVector{<:Real}) where D
-    return AtomPosition{D}(name, get(ELEMENT_LOOKUP, name, 0), pos)
+    return AtomPosition(name, SVector{D,Float64}(pos))
+end
+
+function AtomPosition{D}(num::Integer, pos::AbstractVector{<:Real}) where D
+    return AtomPosition(num, SVector{D,Float64}(pos))
 end
 
 """

--- a/src/atoms.jl
+++ b/src/atoms.jl
@@ -76,7 +76,7 @@ struct AtomList{D} <: AbstractRealSpaceData{D}
     end
 end
 
-function AtomList{D}(
+function AtomList(
     basis::AbstractLattice{D},
     coord::AbstractVector{<:AtomPosition{D}};
     prim=false
@@ -90,8 +90,8 @@ function AtomList{D}(
 end
 
 # Do it without adding a lattice
-function AtomList{D}(coord::AbstractVector{AtomPosition{D}}) where D
-    return AtomList{D}(zeros(BasisVectors{D}), coord)
+function AtomList(coord::AbstractVector{AtomPosition{D}}) where D
+    return AtomList(zeros(BasisVectors{D}), coord)
 end
 
 # Check if an AtomList{D} is empty

--- a/src/atoms.jl
+++ b/src/atoms.jl
@@ -81,7 +81,7 @@ angstroms.
 struct AtomList{D} <: AbstractRealSpaceData{D}
     basis::BasisVectors{D}
     coord::Vector{AtomPosition{D}}
-    function AtomList{D}(
+    function AtomList(
         basis::BasisVectors{D},
         coord::AbstractVector{<:AtomPosition{D}}
     ) where D
@@ -97,9 +97,9 @@ function AtomList(
 ) where D
     # Use either the primitive or conventional vectors depending on user input
     if prim
-        return AtomList{D}(basis.prim, unique(coord))
+        return AtomList(basis.prim, unique(coord))
     else
-        return AtomList{D}(basis.conv, unique(coord))
+        return AtomList(basis.conv, unique(coord))
     end
 end
 

--- a/src/crystals.jl
+++ b/src/crystals.jl
@@ -23,7 +23,7 @@ struct Crystal{D} <: AbstractCrystal{D}
     # Positions of atoms explicitly generated (used to generate templates, XYZs, etc.)
     pos::AtomList{D}
     # Inner constructor
-    function Crystal{D}(
+    function Crystal(
         latt::AbstractLattice{D},
         sgno::Integer,
         orig::AbstractVector{<:Real},

--- a/src/filetypes.jl
+++ b/src/filetypes.jl
@@ -189,7 +189,7 @@ function readXSF3D(
     end
     # Generate the real space lattice
     latt = RealLattice(prim, conv)
-    xtal = Crystal{3}(latt, spgrp, origin, atom_list, atom_list)
+    xtal = Crystal(latt, spgrp, origin, atom_list, atom_list)
     return CrystalWithDatasets{3,String,RealSpaceDataGrid{3}}(xtal, data)
 end
 

--- a/src/filetypes.jl
+++ b/src/filetypes.jl
@@ -70,7 +70,7 @@ function readXSF3D(
             # assign atom position struct
             apos[n] = AtomPosition{3}(num, basis\pos)
         end
-        return AtomList{3}(basis, apos)
+        return AtomList(basis, apos)
     end
     # Function to get grid data
     # By default, trim the edges of the grid (repeated points)

--- a/src/software/abinit.jl
+++ b/src/software/abinit.jl
@@ -182,7 +182,7 @@ symrel_to_sg(h::ABINITHeader) = symrel_to_sg(h.symrel)
 function Crystal(h::ABINITHeader; convert=:P)
     # Lattice vectors converted to angstroms
     latt = BasisVectors{3}(BOHR2ANG*h.rprimd)
-    atomlist = AtomList{3}(
+    atomlist = AtomList(
         latt,
         AtomPosition{3}.(
             Int.(h.znucltypat[h.typat]),

--- a/src/software/abinit.jl
+++ b/src/software/abinit.jl
@@ -184,7 +184,7 @@ function Crystal(h::ABINITHeader; convert=:P)
     latt = BasisVectors{3}(BOHR2ANG*h.rprimd)
     atomlist = AtomList(
         latt,
-        AtomPosition{3}.(
+        AtomPosition.(
             Int.(h.znucltypat[h.typat]),
             h.xred
         )

--- a/src/software/abinit.jl
+++ b/src/software/abinit.jl
@@ -189,7 +189,7 @@ function Crystal(h::ABINITHeader; convert=:P)
             h.xred
         )
     )
-    return Crystal{3}(
+    return Crystal(
         # ABINIT seems to use bohr by default
         RealLattice{3}(BOHR2ANG*h.rprimd, prim=true, ctr=convert),
         symrel_to_sg(h),        # TODO: get space group from header?

--- a/src/software/vasp.jl
+++ b/src/software/vasp.jl
@@ -58,7 +58,7 @@ function readPOSCAR(io::IO; ctr=:P)
     end
     list = AtomList(latt, positions, prim=true)
     # Skip out on velocities for now
-    return Crystal{3}(latt, 1, [0, 0, 0], list, list)
+    return Crystal(latt, 1, [0, 0, 0], list, list)
 end
 
 readPOSCAR(filename::AbstractString; kwargs...) = open(readPOSCAR, filename; kwargs...)

--- a/src/software/vasp.jl
+++ b/src/software/vasp.jl
@@ -52,10 +52,11 @@ function readPOSCAR(io::IO; ctr=:P)
     ctr = 1
     for (n,s) in enumerate(atomnames)
         for x in 1:natomtypes[n]
-            positions[ctr] = AtomPosition(s, parse.(Float64, split(readline(io))))
+            positions[ctr] = AtomPosition{3}(s, parse.(Float64, split(readline(io))))
             ctr = ctr + 1
         end
     end
+    @info "latt:\t" * string(typeof(latt))
     list = AtomList(latt, positions, prim=true)
     # Skip out on velocities for now
     return Crystal(latt, 1, [0, 0, 0], list, list)

--- a/src/software/vasp.jl
+++ b/src/software/vasp.jl
@@ -56,7 +56,7 @@ function readPOSCAR(io::IO; ctr=:P)
             ctr = ctr + 1
         end
     end
-    list = AtomList{3}(latt, positions, prim=true)
+    list = AtomList(latt, positions, prim=true)
     # Skip out on velocities for now
     return Crystal{3}(latt, 1, [0, 0, 0], list, list)
 end

--- a/src/software/vasp.jl
+++ b/src/software/vasp.jl
@@ -52,7 +52,7 @@ function readPOSCAR(io::IO; ctr=:P)
     ctr = 1
     for (n,s) in enumerate(atomnames)
         for x in 1:natomtypes[n]
-            positions[ctr] = AtomPosition{3}(s, parse.(Float64, split(readline(io))))
+            positions[ctr] = AtomPosition(s, parse.(Float64, split(readline(io))))
             ctr = ctr + 1
         end
     end


### PR DESCRIPTION
These types have inner constructors that require the supply of the dimension type parameter, but at the same time the constructors require the use of types that already have dimension information (for instance, `SVector{D,T}`, `BasisVectors{D}`). I believe I've fixed all calls to these functions within the library, but let me know if this breaks other functionality you may be using.