### PR TITLE
Fixed broken subtyping for `CrystalWithDatasets`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,7 @@ authors = [
     "Amber Lim <xalim@wisc.edu>", 
     "Patrick Cross <pcross@wisc.edu>"
 ]
-version = "0.1.11"
+version = "0.1.12"
 
 [deps]
 ComputedFieldTypes = "459fdd68-db75-56b8-8c15-d717a790f88e"

--- a/src/crystals.jl
+++ b/src/crystals.jl
@@ -50,7 +50,7 @@ end
 
 A pairing of a `Crystal{D}` and a `Dict{K,V}` which allows for access to associated datasets.
 """
-struct CrystalWithDatasets{D,K,V} <: AbstractCrystalData{D}
+struct CrystalWithDatasets{D,K,V} <: AbstractCrystal{D}
     xtal::Crystal{D}
     data::Dict{K,V}
 end


### PR DESCRIPTION
It was inheriting from `AbstractCrystalData` and not `AbstractCrystal`