### PR TITLE
Applying functions to `RealSpaceDataGrid`

### DIFF
--- a/src/data.jl
+++ b/src/data.jl
@@ -53,6 +53,16 @@ function RealSpaceDataGrid(
     end
 end
 
+"""
+    RealSpaceDataGrid(f, g::RealSpaceDataGrid)
+
+Applies a function `f` elementwise to the grid elements of a `RealSpaceDataGrid` and returns a new
+`RealSpaceDataGrid`.
+"""
+function RealSpaceDataGrid(f, g::RealSpaceDataGrid)
+    return RealSpaceDataGrid(basis(g), shift(g), f.(grid(g)))
+end
+
 # getindex supports arbitrary integer indices for RealSpaceDataGrid
 function Base.getindex(g::RealSpaceDataGrid, inds...)
     # Perform modulo math to get the indices

--- a/src/data.jl
+++ b/src/data.jl
@@ -161,6 +161,15 @@ function integrate(g::RealSpaceDataGrid{D,T}) where {D,T<:Number}
 end
 
 """
+    integrate(f, g::RealSpaceDataGrid{D,T<:Number}) -> <:Number
+
+Applies the function `f` pointwise to the elements of a datagrid, then integrates the grid.
+"""
+function integrate(f, g::RealSpaceDataGrid{D,T}) where {D,T<:Number}
+    return sum(f.(grid(g))) * voxelsize(g)
+end
+
+"""
     fft(g::RealSpaceDataGrid{D,<:Number}; maxhkl=zeros(Int,D)) -> HKLData{D,<:Complex}
 
 Performs a fast Fourier transform on the data in a `RealSpaceDataGrid{D,<:Number}` and


### PR DESCRIPTION
I've extended the `integrate()` function to allow for the application of an arbitrary function to a `RealSpaceDataGrid` elementwise. This should be useful when integrating wavefunctions to get the electron density: you can call `integrate((x -> x^2), g)` to square the values of the grid `g` before integrating it.

In a similar vein, I've added a new `RealSpaceDataGrid` constructor that can generate a new `RealSpaceDataGrid` with some function applied. 