### PR TITLE
Conversion between `RealSpaceDataGrid` indices and cartesian coordinates

### DIFF
--- a/src/Xtal.jl
+++ b/src/Xtal.jl
@@ -119,8 +119,8 @@ include("data.jl")
 export RealSpaceDataGrid, KPointGrid, KPointList, BandAtKPoint, BandStructure, HKLData, HKLDict,
        ReciprocalWavefunction, DensityOfStates, ProjectedDensityOfStates, FatBands, AtomicData,
        SphericalComponents
-export grid, gridsize, volume, voxelsize, integrate, fft, nkpt, nband, bounds, fermi, smear,
-       energies, nelectrons
+export grid, gridsize, volume, voxelsize, coord, nearest_index, integrate, fft, nkpt, nband, 
+       bounds, fermi, smear, energies, nelectrons
 include("potentials.jl")
 export XCFunctional, HGHPseudopotential, zatom, zion
 # Methods and structs for working with different file formats

--- a/src/data.jl
+++ b/src/data.jl
@@ -119,6 +119,32 @@ By default, units are assumed to be cubic angstroms.
 voxelsize(g::RealSpaceDataGrid) = volume(g) / prod(gridsize(g))
 
 """
+    coord(g::RealSpaceDataGrid, ind...) -> SVector{D,Float64}
+
+Returns the Cartesian coordinate associated with a grid datum at a given index.
+"""
+function coord(g::RealSpaceDataGrid{D,T}, ind::AbstractVector{<:Integer}) where {D,T}
+    return basis(g) * (ind ./ size(g))
+end
+
+function coord(g::RealSpaceDataGrid{D,T}, ind::Vararg{<:Integer,D}) where {D,T}
+    return coord(g, SVector{D,Int}(ind))
+end
+
+"""
+    nearest_index(g::RealSpaceDataGrid{D,T}, coord::AbstractVector{<:Real}) -> NTuple{D,Int}
+
+Gets the nearest integer index in a data grid associated with a Cartesian coordinate.
+
+The value returned by this function provides an index that may lie outside of the range of indices
+of the backing array. However, due to the definition of `getindex()` for `RealSpaceDataGrid`, which
+takes advantage of crystal periodicity, the index is guaranteed to return a value.
+"""
+function nearest_index(g::RealSpaceDataGrid{D,T}, coord::AbstractVector{<:Real}) where {D,T}
+    return Tuple(round.(Int, (basis(g) \ coord) .* size(g)))
+end
+
+"""
     Xtal.grid_check(g1::RealSpaceDataGrid, g2::RealSpaceDataGrid)
 
 Performs a check on two `RealSpaceDataGrid`s to ensure that the basis, origin shift, and grid

--- a/src/data.jl
+++ b/src/data.jl
@@ -98,7 +98,7 @@ grid(g::RealSpaceDataGrid) = g.grid
 Gets the dimensions of the backing array corresponding to a `RealSpaceDataGrid`.
 """
 gridsize(g::RealSpaceDataGrid) = size(g.grid)
-#Base.size(g::RealSpaceDataGrid) = gridsize(g)
+Base.size(g::RealSpaceDataGrid) = size(g.grid)
 
 """
     volume(g::RealSpaceDataGrid) -> Float64


### PR DESCRIPTION
This should be useful for when we need to determine distances between grid points or find the nearest atom to a specific grid point.