### PR TITLE
Fixed scaling for FFT result

### DIFF
--- a/src/data.jl
+++ b/src/data.jl
@@ -196,7 +196,8 @@ function FFTW.fft(
     shifts = [last(b) for b in bounds]
     # Take the grid fft
     # Permute the elements to get the indexing working
-    f = circshift(fft(grid(g)), shifts .+ 1)
+    # Multiply by the size of a voxel to get the right scaling
+    f = circshift(fft(grid(g)), shifts .+ 1) .* voxelsize(g)
     # With defined bounds, truncate the data
     if all(!iszero, maxhkl)
         ind = [(-x:x) .- first(b) .+ 1 for (x,b) in zip(abs.(maxhkl), bounds)]


### PR DESCRIPTION
I forgot that FFTs scale with the number of grid points, so I needed to compensate for that. (Also, the size of the cell too - that's pretty important)