### PR TITLE
Added unit support to display methods for objects with units

### DIFF
--- a/src/show.jl
+++ b/src/show.jl
@@ -36,19 +36,19 @@ function basis_string(
             ]
 end
 
-basis_string(b::BasisVectors; kwargs...) = basis_string(matrix(b), kwargs...)
+basis_string(b::BasisVectors; kwargs...) = basis_string(matrix(b); kwargs...)
 
 function printbasis(io::IO, M::AbstractMatrix{<:Real}; letters=true, unit="", pad=0)
     s = basis_string(M, letters=letters, unit=unit)
     print(io, join(" "^pad .* s, "\n"))
 end
 
-printbasis(io::IO, b::BasisVectors; letters=true, pad=0) = 
-    printbasis(io::IO, matrix(b), letters=letters, pad=pad)
-printbasis(io::IO, a::AtomList; letters=true, pad=0) = 
-    printbasis(io, basis(a), letters=letters, pad=pad)
-printbasis(io::IO, g::RealSpaceDataGrid{D,T} where {D,T}; letters=true, pad=0) =
-    printbasis(io, basis(g), letters=letters, pad=pad)
+printbasis(io::IO, b::BasisVectors; kwargs...) = 
+    printbasis(io::IO, matrix(b), letters=true, pad=0; kwargs...)
+printbasis(io::IO, a::AtomList; kwargs...) = 
+    printbasis(io, basis(a), letters=true, pad=0; kwargs...)
+printbasis(io::IO, g::RealSpaceDataGrid{D,T} where {D,T}; kwargs...) =
+    printbasis(io, basis(g), letters=true, pad=0; kwargs...)
 
 """
     atom_string(a::AtomPosition; name=true, num=true)
@@ -95,7 +95,7 @@ formula_string(a::AtomList{D}; reduce=true) where D = formula_string(a.coord, re
 
 function Base.show(io::IO, ::MIME"text/plain", b::BasisVectors)
     println(io, typeof(b), ":")
-    printbasis(io, b, pad=2)
+    printbasis(io, b, pad=2, unit="Å")
 end
 
 function Base.show(io::IO, ::MIME"text/plain", a::AtomPosition; name=true, num=true)
@@ -119,9 +119,9 @@ end
 function Base.show(io::IO, ::MIME"text/plain", g::RealSpaceDataGrid{D,T}) where {D,T}
     dimstring = join(string.(gridsize(g)), "×") * " "
     println(io, dimstring, typeof(g), " with basis vectors:")
-    print(join(basis_string(basis(g)), "\n"))
-    println("\nCell volume: ", volume(g))
-    print("Voxel size: ", voxelsize(g))
+    print(join(basis_string(basis(g), unit="Å"), "\n"))
+    println("\nCell volume: ", volume(g), " Å³")
+    print("Voxel size: ", voxelsize(g), " Å³")
 end
 
 # ReciprocalWavefunction{D,T}
@@ -132,9 +132,9 @@ end
 
 function Base.show(io::IO, ::MIME"text/plain", l::AbstractLattice{D}) where D
     println(io, typeof(l), ":\n\n  Primitive basis vectors:")
-    printbasis(io, l.prim)
+    printbasis(io, l.prim, unit="Å")
     println(io, "\n\n  Conventional basis vectors:")
-    printbasis(io, l.conv)
+    printbasis(io, l.conv, unit="Å")
 end
 
 # TODO: Get rid of direct struct access
@@ -143,9 +143,9 @@ function Base.show(io::IO, ::MIME"text/plain", xtal::Crystal{D}) where D
     println(io, typeof(xtal), " (space group ", xtal.sgno, "): ")
     # Print basis vectors
     println(io, "\n  Primitive basis vectors:")
-    printbasis(io, xtal.latt.prim, pad=2)
+    printbasis(io, xtal.latt.prim, pad=2, unit="Å")
     println(io, "\n\n  Conventional basis vectors:")
-    printbasis(io, xtal.latt.conv, pad=2)
+    printbasis(io, xtal.latt.conv, pad=2, unit="Å")
     # Add in more info about atomic positions, space group
     println(io, "\n\n  Generating set of atomic positions:")
     println(io, "    Num   ", "Name  ", "Position")

--- a/src/show.jl
+++ b/src/show.jl
@@ -38,8 +38,8 @@ end
 
 basis_string(b::BasisVectors; kwargs...) = basis_string(matrix(b), kwargs...)
 
-function printbasis(io::IO, M::AbstractMatrix{<:Real}; letters=true, pad=0)
-    s = basis_string(M, letters=letters)
+function printbasis(io::IO, M::AbstractMatrix{<:Real}; letters=true, unit="", pad=0)
+    s = basis_string(M, letters=letters, unit=unit)
     print(io, join(" "^pad .* s, "\n"))
 end
 

--- a/src/show.jl
+++ b/src/show.jl
@@ -132,9 +132,9 @@ end
 
 function Base.show(io::IO, ::MIME"text/plain", l::AbstractLattice{D}) where D
     println(io, typeof(l), ":\n\n  Primitive basis vectors:")
-    printbasis(io, l.prim, unit="Å")
+    printbasis(io, l.prim, unit="Å" * "⁻¹"^(l isa ReciprocalLattice))
     println(io, "\n\n  Conventional basis vectors:")
-    printbasis(io, l.conv, unit="Å")
+    printbasis(io, l.conv, unit="Å" * "⁻¹"^(l isa ReciprocalLattice))
 end
 
 # TODO: Get rid of direct struct access

--- a/src/show.jl
+++ b/src/show.jl
@@ -19,7 +19,8 @@ function basis_string(
     pad="  ",
     brackets=true,
     letters=true,
-    length=true
+    length=true,
+    unit=""
 )
     # Format the numbers within a vector
     tostr(x, n) = lpad(@sprintf("%f", x), n)
@@ -30,7 +31,7 @@ function basis_string(
     return [
                 pad * string(Char(0x60 + n), ':', ' ')^letters *
                 vector_string(M[:,n], brackets=brackets) *
-                ("   (" * tostr(norm(M[:,n]), 0))^length * ")"
+                ("   (" * tostr(norm(M[:,n]), 0))^length * " "^!isempty(unit) * unit * ")"
                 for n in 1:size(M)[2]
             ]
 end

--- a/src/show.jl
+++ b/src/show.jl
@@ -123,12 +123,6 @@ function Base.show(io::IO, ::MIME"text/plain", g::RealSpaceDataGrid{D,T}) where 
     print("Voxel size: ", voxelsize(g))
 end
 
-#= Crystal{D}
-function Base.show(io::IO, ::MIME"text/plain", xtal::Crystal{D})
-    println(io, )
-end
-=#
-
 # ReciprocalWavefunction{D,T}
 function Base.show(io::IO, ::MIME"text/plain", wf::ReciprocalWavefunction{D,T}) where {D,T}
     println(io,


### PR DESCRIPTION
`BasisVectors`, `Crystal`, `RealLattice`, `ReciprocalLattice` and `RealSpaceDataGrid` will now show default units (angstroms or cubic angstroms). Some of the internal functions uses to generate strings will also support the `unit` keyword for unit specification.

This should serve as a visual reminder when working with lengths, because some packages may use Bohr or other units for that purpose.