### PR TITLE
Datagrid length

### DIFF
--- a/src/data.jl
+++ b/src/data.jl
@@ -102,6 +102,7 @@ Gets the dimensions of the backing array corresponding to a `RealSpaceDataGrid`.
 """
 gridsize(g::RealSpaceDataGrid) = size(g.grid)
 Base.size(g::RealSpaceDataGrid) = size(g.grid)
+Base.length(g::RealSpaceDataGrid) = length(g.grid)
 
 """
     volume(g::RealSpaceDataGrid) -> Float64

--- a/src/data.jl
+++ b/src/data.jl
@@ -100,9 +100,9 @@ grid(g::RealSpaceDataGrid) = g.grid
 
 Gets the dimensions of the backing array corresponding to a `RealSpaceDataGrid`.
 """
-gridsize(g::RealSpaceDataGrid) = size(g.grid)
-Base.size(g::RealSpaceDataGrid) = size(g.grid)
-Base.length(g::RealSpaceDataGrid) = length(g.grid)
+gridsize(g::RealSpaceDataGrid) = size(grid(g))
+Base.size(g::RealSpaceDataGrid) = size(grid(g))
+Base.length(g::RealSpaceDataGrid) = length(grid(g))
 
 """
     volume(g::RealSpaceDataGrid) -> Float64


### PR DESCRIPTION
Apparently not having `length()` defined for `RealSpaceDataGrid` breaks multiplication and iteration...