### PR TITLE
Added basis vector specification to `HKLData`

### DIFF
--- a/src/data.jl
+++ b/src/data.jl
@@ -519,6 +519,11 @@ function shiftbounds(hkl::HKLData{D,T}, inds) where {D,T}
     return i
 end
 
+"""
+    basis(hkl::HKLData)
+
+Returns the real-space basis associated with an `HKLData` object.
+"""
 basis(hkl::HKLData) = hkl.basis
 
 """

--- a/src/data.jl
+++ b/src/data.jl
@@ -519,6 +519,8 @@ function shiftbounds(hkl::HKLData{D,T}, inds) where {D,T}
     return i
 end
 
+basis(hkl::HKLData) = hkl.basis
+
 """
     grid(hkl::HKLData{D,T}) -> Array{T,D}
 

--- a/src/data.jl
+++ b/src/data.jl
@@ -468,23 +468,33 @@ Stores information associated with specific sets of reciprocal lattice vectors. 
 accessed and modified using regular indexing, where indices may be negative.
 """
 struct HKLData{D,T} <: AbstractHKL{D,T}
+    # REAL SPACE basis vectors
+    basis::BasisVectors{D}
     # the actual data
     data::Array{T,D}
     # the bounds in each dimension
     # mutable since the dimensions of Array{D,T} can be changed, in principle
     bounds::MVector{D,UnitRange{Int}}
     function HKLData(
+        basis::BasisVectors{D},
         data::AbstractArray{T,D},
         bounds::AbstractVector{<:AbstractRange{<:Integer}}
     ) where {D,T}
         # The size of the array should match the bounds given
-        # For instance, a HKLData with bounds  [-10:10, -10:10, -10:10] should Be
+        # For instance, a HKLData with bounds  [-10:10, -10:10, -10:10] should be
         # [21, 21, 21]
         @assert [s for s in size(data)] == [length(r) for r in bounds] string(
             "Array size incompatible with bounds."
         )
-        return new{D,T}(data, bounds)
+        return new{D,T}(basis, data, bounds)
     end
+end
+
+function HKLData(
+    data::AbstractArray{T,D},
+    bounds::AbstractVector{<:AbstractRange{<:Integer}}
+) where {D,T}
+    return HKLData(zero(BasisVectors{D}), data, bounds)
 end
 
 # Needed because HKLData will nearly always have unexpected indices

--- a/src/show.jl
+++ b/src/show.jl
@@ -95,7 +95,7 @@ formula_string(a::AtomList{D}; reduce=true) where D = formula_string(a.coord, re
 
 function Base.show(io::IO, ::MIME"text/plain", b::BasisVectors)
     println(io, typeof(b), ":")
-    printbasis(io, b, pad=2, unit="Å")
+    printbasis(io, b, pad=2)
 end
 
 function Base.show(io::IO, ::MIME"text/plain", a::AtomPosition; name=true, num=true)


### PR DESCRIPTION
This is necessary for correctly performing FFTs, since `RealSpaceDataGrid` has the basis vectors provided.

Note that the newly defined `basis(::HKLData)` returns the *real space* vectors in accordance with all other instances of `basis()`. In the future I do want to have `RealBasis` and `ReciprocalBasis` be their own types.

As one final test, the varinfo output for the WAVECAR I use for testing is given below:

```julia-repl
julia> varinfo(r"ans")
  name        size summary                           
  –––– ––––––––––– ––––––––––––––––––––––––––––––––––
  ans  547.819 MiB ReciprocalWavefunction{3, Float32}
```

This is a ~350 KiB increase from before (547.466 MiB), so overall the additional data is not very significant.