### PR TITLE
Broadened `integrate(f::Function, g::RealSpaceDataGrid{D,T})` to accept any data type `T`

### DIFF
--- a/src/data.jl
+++ b/src/data.jl
@@ -212,7 +212,7 @@ end
 Base.conj(g::RealSpaceDataGrid) = RealSpaceDataGrid(conj, g)
 
 """
-    integrate(g::RealSpaceDataGrid{D,T<:Number}) -> <:Number
+    integrate(g::RealSpaceDataGrid{D,T<:Number}) -> T
 
 Performs an integration across all voxels, returning a scalar value.
 """
@@ -221,11 +221,11 @@ function integrate(g::RealSpaceDataGrid{D,T}) where {D,T<:Number}
 end
 
 """
-    integrate(f, g::RealSpaceDataGrid{D,T<:Number}) -> <:Number
+    integrate(f::Function, g::RealSpaceDataGrid) -> <:Number
 
 Applies the function `f` pointwise to the elements of a datagrid, then integrates the grid.
 """
-function integrate(f, g::RealSpaceDataGrid{D,T}) where {D,T<:Number}
+function integrate(f::Function, g::RealSpaceDataGrid)
     return sum(f.(grid(g))) * voxelsize(g)
 end
 

--- a/src/data.jl
+++ b/src/data.jl
@@ -212,16 +212,16 @@ end
 Base.conj(g::RealSpaceDataGrid) = RealSpaceDataGrid(conj, g)
 
 """
-    integrate(g::RealSpaceDataGrid{D,T<:Number}) -> T
+    integrate(g::RealSpaceDataGrid{D,T}) -> T
 
 Performs an integration across all voxels, returning a scalar value.
 """
-function integrate(g::RealSpaceDataGrid{D,T}) where {D,T<:Number}
+function integrate(g::RealSpaceDataGrid)
     return sum(grid(g)) * voxelsize(g)
 end
 
 """
-    integrate(f::Function, g::RealSpaceDataGrid) -> <:Number
+    integrate(f::Function, g::RealSpaceDataGrid{D,T}) -> T
 
 Applies the function `f` pointwise to the elements of a datagrid, then integrates the grid.
 """

--- a/src/data.jl
+++ b/src/data.jl
@@ -223,7 +223,8 @@ end
 """
     integrate(f::Function, g::RealSpaceDataGrid{D,T}) -> T
 
-Applies the function `f` pointwise to the elements of a datagrid, then integrates the grid.
+Applies the function `f` pointwise to the elements of a datagrid, then integrates the grid across
+all voxels.
 """
 function integrate(f::Function, g::RealSpaceDataGrid)
     return sum(f.(grid(g))) * voxelsize(g)


### PR DESCRIPTION
I found this to be a problem when integrating vector fields. In principle, `T` can be anything as long as `f()` returns a number type.