### PR TITLE
Fixes and improvements for `BasisVectors`

### DIFF
--- a/src/lattices.jl
+++ b/src/lattices.jl
@@ -267,14 +267,14 @@ Returns the lengths of the constituent vectors in a matrix representing cell vec
 cell_lengths(M::AbstractMatrix) = [norm(M[:,n]) for n = 1:size(M,2)]
 # TODO: perhaps this is not necessary anymore
 # But removing it might break the API
-cell_lengths(b::BasisVectors) = cell_lengths(matrix(b))
+cell_lengths(b::BasisVectors) = SVector{D}(norm(v) for v in b)
 
 """
     lengths(b::BasisVectors) -> Vector{Float64}
 
 Returns the lengths of the constituent vectors in a matrix representing cell vectors.
 """
-lengths(b::BasisVectors) = cell_lengths(matrix(b))
+lengths(b::BasisVectors{D}) = SVector{D}(norm(v) for v in b)
 
 """
     cell_volume(M::AbstractMatrix) -> Float64

--- a/src/lattices.jl
+++ b/src/lattices.jl
@@ -275,6 +275,8 @@ cell_lengths(b::BasisVectors) = SVector{D}(norm(v) for v in b)
 Returns the lengths of the constituent vectors in a matrix representing cell vectors.
 """
 lengths(b::BasisVectors{D}) = SVector{D}(norm(v) for v in b)
+# Get the vector lengths for anything that has a defined basis
+lengths(x) = lengths(basis(x))
 
 """
     cell_volume(M::AbstractMatrix) -> Float64
@@ -294,6 +296,8 @@ Returns the volume of a unit cell defined by a matrix. This volume does not carr
 (negative for cells that do not follow the right hand rule).
 """
 volume(b::BasisVectors) = cell_volume(matrix(b))
+# Get the cell volume for anything that has a defined basis
+volume(x) = volume(basis(x))
 
 """
     volume(l::AbstractLattice; primitive=true) -> Float64

--- a/src/lattices.jl
+++ b/src/lattices.jl
@@ -79,7 +79,7 @@ matrix(b::BasisVectors{D}) where D = SMatrix{D,D,Float64}(b[m,n] for m in 1:D, n
 # This is needed for broadcasting
 Base.length(b::BasisVectors) = length(b.vs)
 Base.iterate(b::BasisVectors, state) = iterate(b.vs, state) 
-Base.iterate(b::BasisVectors) = iterate(b, 1)
+Base.iterate(b::BasisVectors) = iterate(b.vs)
 
 # TODO: does this make sense?
 Base.convert(::Type{SMatrix{D,D,Float64}}, b::BasisVectors{D}) where D = matrix(b)


### PR DESCRIPTION
The iteration protocol for `BasisVectors` was broken, so I fixed that. I also fixed `lengths()` so that it returns an `SVector{D,Float64}` for `BasisVectors` arguments (previously returned a `Vector{Float64}`).