### PR TITLE
Fftfreq fix

### DIFF
--- a/src/data.jl
+++ b/src/data.jl
@@ -238,7 +238,7 @@ Returns the discrete Fourier transform frequency bins for a `RealSpaceDataGrid`.
 function FFTW.fftfreq(g::RealSpaceDataGrid{D,<:Any}) where D
     return collect(
         Iterators.product(
-            (fftfreq(size(g)[d], lengths(basis(g))[d]) for d in 1:D)...
+            (fftfreq(size(g)[d], size(g)[d]/lengths(basis(g))[d]) for d in 1:D)...
         )
     )
 end

--- a/src/data.jl
+++ b/src/data.jl
@@ -238,7 +238,7 @@ Returns the discrete Fourier transform frequency bins for a `RealSpaceDataGrid`.
 function FFTW.fftfreq(g::RealSpaceDataGrid{D,<:Any}) where D
     return collect(
         Iterators.product(
-            (fftfreq(size(g)[d], size(g)[d]/lengths(basis(g))[d]) for d in 1:D)...
+            (fftfreq(size(g)[d], size(g)[d] / lengths(basis(g))[d]) for d in 1:D)...
         )
     )
 end


### PR DESCRIPTION
The arguments to `fftfreq()` are supposed to be the number of samples and the sampling rate, but the length of the basis vector was use instead of the sampling rate along that vector.