### PR TITLE
API updates with export fixes

### DIFF
--- a/src/Xtal.jl
+++ b/src/Xtal.jl
@@ -80,6 +80,7 @@ The value of 2m_e/ħ^2 as used in VASP (eV^-1 * angstrom^-2, but not exactly).
 const CVASP = 0.262465831
 # the correct value is actually 0.26246842360751754
 
+# Functionality here has been superseded by allequal() in Julia 1.8.0
 """
     Xtal._allsame(itr)
 

--- a/src/Xtal.jl
+++ b/src/Xtal.jl
@@ -109,7 +109,7 @@ export dual, prim, conv, cell_lengths, cell_volume, lengths, volume, lattice2D, 
 # Methods and structs for working with atomic positions
 include("atoms.jl")
 export AtomPosition, AtomList
-export atomname, atomicno, coord, natom, basis, cartesian, reduce_coords, natomtypes
+export atomname, atomicno, coord, natom, basis, cartesian, reduce_coords, supercell, natomtypes
 # Methods and structs for working with crystal data
 include("crystals.jl")
 export Crystal, CrystalWithDatasets

--- a/src/Xtal.jl
+++ b/src/Xtal.jl
@@ -104,8 +104,8 @@ export AbstractLattice, AbstractCrystal, AbstractCrystalData, AbstractRealSpaceD
 # Methods and structs for working with crystal lattices
 include("lattices.jl")
 export BasisVectors, RealLattice, ReciprocalLattice
-export dual, prim, conv, cell_lengths, cell_volume, lengths, volume, lattice2D, lattice3D,
-       maxHKLindex
+export triangularize, dual, prim, conv, cell_lengths, cell_volume, lengths, volume, lattice2D, 
+       lattice3D, maxHKLindex
 # Methods and structs for working with atomic positions
 include("atoms.jl")
 export AtomPosition, AtomList

--- a/src/vectors.jl
+++ b/src/vectors.jl
@@ -16,6 +16,7 @@ function is_linearly_independent(vecs::AbstractVector{<:Number}...)
     return is_linearly_independent(hcat(vecs...))
 end
 
+#= This functionality is unneeded due to FFTW.fftfreq
 """
     Xtal.fbin(i::Integer) -> Vector{Int}
     Xtal.fbin(v::AbstractVector) -> Vector{Int}
@@ -72,6 +73,7 @@ julia> fbins(6,5)
 fbins(i::Integer...) = collect(Iterators.product((fbin(x) for x in i)...))
 fbins(s::SArray{S,<:Any,N}) where {S,N} = SArray{S,NTuple{N,Int}}(fbins(size(s)...))
 fbins(a) = fbins(size(a)...)
+=#
 
 #=
 """


### PR DESCRIPTION
It seems that `supercell()` wasn't exported in 0.1.18, and `triangularize()` probably also deserved to be exported as well. 