### PR TITLE
Crystal updates

### DIFF
--- a/src/crystals.jl
+++ b/src/crystals.jl
@@ -93,20 +93,17 @@ end
 Crystal(xtaldata::CrystalWithDatasets{D,K,V}) where {D,K,V} = xtaldata.xtal
 data(xtaldata::CrystalWithDatasets{D,K,V}) where {D,K,V} = xtaldata.data
 
-RealLattice(xtal::Crystal) = xtal.latt
-ReciprocalLattice(xtal::Crystal) = ReciprocalLattice(xtal.latt)
+RealLattice(xtal::AbstractCrystal) = xtal.latt
+ReciprocalLattice(xtal::AbstractCrystal) = ReciprocalLattice(xtal.latt)
 
-prim(xtal::Crystal) = prim(RealLattice(xtal))
-conv(xtal::Crystal) = conv(RealLattice(xtal))
+prim(xtal::AbstractCrystal) = prim(RealLattice(xtal))
+conv(xtal::AbstractCrystal) = conv(RealLattice(xtal))
 
-basis(xtal::Crystal; primitive::Bool=false) = primitive ? prim(xtal.latt) : conv(xtal.latt)
-basis(xtaldata::CrystalWithDatasets; primitive::Bool=false) = basis(xtaldata.xtal; primitive)
+basis(xtal::AbstractCrystal; primitive::Bool=false) = primitive ? prim(xtal.latt) : conv(xtal.latt)
 
-volume(xtal::Crystal; primitive::Bool=false) = volume(xtal.latt; primitive)
-volume(xtaldata::CrystalWithDatasets; primitive::Bool=false) = volume(xtaldata.xtal; primitive)
+volume(xtal::AbstractCrystal; primitive::Bool=false) = volume(xtal.latt; primitive)
 
-atoms(xtal::Crystal) = xtal.pos
-atoms(xtaldata::CrystalWithDatasets) = xtaldata.xtal.pos
+atoms(xtal::AbstractCrystal) = xtal.pos
 
 # TODO: fix this so that it gets the right number of atoms regardless of space group
 """
@@ -117,16 +114,16 @@ Returns the number of atoms in a crystal's unit cell.
 This function is currently not aware of space groups or settings, so if the generating set does not
 contain all the atoms in the cell, it will return the wrong value.
 """
-natom_cell(xtal::Crystal) = natom(xtal.gen)
+natom_cell(xtal::AbstractCrystal) = natom(xtal.gen)
 
 """
     natom_template(xtal::Crystal)
 
 Returns the number of atoms in the crystal template.
 """
-natom_template(xtal::Crystal) = natom(xtal.pos)
+natom_template(xtal::AbstractCrystal) = natom(xtal.pos)
 
-natomtypes(xtal::Crystal) = natomtypes(xtal.pos)
+natomtypes(xtal::AbstractCrystal) = natomtypes(xtal.pos)
 
 #=
 """

--- a/src/crystals.jl
+++ b/src/crystals.jl
@@ -55,6 +55,28 @@ struct CrystalWithDatasets{D,K,V} <: AbstractCrystal{D}
     data::Dict{K,V}
 end
 
+# Expose the constituent crystal's fields
+Base.propertynames(::CrystalWithDatasets) = tuple(
+    fieldnames(CrystalWithDatasets)...,
+    fieldnames(Crystal)...,
+    fieldnames(Dict)...
+)
+
+function Base.getproperty(xtal::CrystalWithDatasets, f::Symbol)
+    # Core fields
+    if f in fieldnames(CrystalWithDatasets)
+        return getfield(xtal, f)
+    # Fields in the Crystal{D}
+    elseif f in fieldnames(Crystal)
+        return getproperty(getfield(xtal, :xtal), f)
+    # Fields in the Dict{K,V}
+    elseif f in fieldnames(Dict)
+        return getproperty(getfield(xtal, :data), f)
+    else
+        error("type CrystalWithDatasets has no field ", string(f))
+    end
+end
+
 # Allow for getting datasets by key; no need to reach into the Dict
 # TODO: figure out how autocompletion works and how to enable it here
 # UPDATE: seems like it's hard-coded into the REPL for `AbstractDict`


### PR DESCRIPTION
I expanded `getproperty()` for CrystalWithDatasets to expose the same interface as `Crystal` which should simplify a lot of internal methods that need direct access to fields/properties.