### PR TITLE
POSCAR writing functionality (VASP 4.6)

### DIFF
--- a/src/Xtal.jl
+++ b/src/Xtal.jl
@@ -110,7 +110,8 @@ export triangularize, dual, prim, conv, cell_lengths, cell_volume, lengths, volu
 # Methods and structs for working with atomic positions
 include("atoms.jl")
 export AtomPosition, AtomList
-export atomname, atomicno, coord, natom, basis, cartesian, reduce_coords, supercell, natomtypes
+export atomname, atomicno, coord, natom, basis, cartesian, reduce_coords, supercell, atomtypes,
+       natomtypes
 # Methods and structs for working with crystal data
 include("crystals.jl")
 export Crystal, CrystalWithDatasets

--- a/src/Xtal.jl
+++ b/src/Xtal.jl
@@ -129,7 +129,7 @@ export XCFunctional, HGHPseudopotential, zatom, zion
 include("filetypes.jl")
 export readXYZ, writeXYZ, readXSF3D, readXSF, writeXSF, readCPcoeff, readCPgeo, readCPcell
 export read_abinit_density, read_abinit_potential, read_abinit_wavefunction, readHGH
-export readPOSCAR, readWAVECAR, readDOSCAR, readPROCAR
+export readPOSCAR, writePOSCAR4, readWAVECAR, readDOSCAR, readPROCAR
 export write_lammps_data
 # Show methods for pretty printing this module's structs
 include("show.jl")

--- a/src/Xtal.jl
+++ b/src/Xtal.jl
@@ -110,8 +110,8 @@ export triangularize, dual, prim, conv, cell_lengths, cell_volume, lengths, volu
 # Methods and structs for working with atomic positions
 include("atoms.jl")
 export AtomPosition, AtomList
-export atomname, atomicno, coord, natom, basis, cartesian, reduce_coords, supercell, atomtypes,
-       natomtypes
+export atomname, atomicno, sort_atomino, coord, natom, basis, cartesian, reduce_coords, supercell,
+       atomtypes, natomtypes
 # Methods and structs for working with crystal data
 include("crystals.jl")
 export Crystal, CrystalWithDatasets

--- a/src/atoms.jl
+++ b/src/atoms.jl
@@ -118,6 +118,15 @@ Base.size(l::AtomList) = size(l.coord)
 Base.iterate(l::AtomList) = iterate(l.coord)
 Base.iterate(l::AtomList, n) = iterate(l.coord, n)
 
+"""
+    sort_atomicno(l::AtomList; rev=false) -> AtomList
+
+Sorts an `AtomList` by atomic number, return a new `AtomList` with the sorted elements.
+
+The `rev` keyword is supported if a reversed order is desired.
+"""
+sort_atomicno(l::AtomList; kwargs...) = AtomList(basis(l), sort(l.coord, by=atomicno; kwargs...))
+
 basis(l::AtomList) = l.basis
 coord(l::AtomList) = l.coord
 natom(l::AtomList) = length(coord(l))

--- a/src/atoms.jl
+++ b/src/atoms.jl
@@ -221,6 +221,14 @@ Removes dummy atoms from an `AtomList`.
 """
  remove_dummies(l::AtomList) = AtomList(basis(l), filter(x -> !iszero(atomicno(x)), l.coord))
 
+ """
+    atomtypes(l::AtomList; dummy=false) -> Int
+
+Returns the atomic numbers of all the atoms in the `AtomList`. The `dummy` keyword controls whether
+dummy atoms are counted as a separate atom type (`false` by default).
+"""
+atomtypes(l::AtomList; dummy=false) = unique([atomicno(a) for a in l])
+
 """
     natomtypes(l::AtomList; dummy=false) -> Int
 
@@ -228,10 +236,8 @@ Returns the number of types of atoms. The `dummy` keyword controls whether dummy
 as a separate atom type (`false` by default).
 """
 function natomtypes(l::AtomList; dummy=false)
-    # Collect all of the atom types
-    types = [atomicno(a) for a in l]
     # Subtract any dummy atoms
-    return length(unique(types)) - (!dummy * (0 in types))
+    return length(atomtypes(l, dummy=dummy)) - (!dummy * (0 in types))
     # (There's probably a more efficient implementation, but this works)
 end
 

--- a/src/crystals.jl
+++ b/src/crystals.jl
@@ -123,7 +123,8 @@ Returns the number of atoms in the crystal template.
 """
 natom_template(xtal::AbstractCrystal) = natom(xtal.pos)
 
-natomtypes(xtal::AbstractCrystal) = natomtypes(xtal.pos)
+atomtypes(xtal::AbstractCrystal) = atomtypes(xtal.gen)
+natomtypes(xtal::AbstractCrystal) = natomtypes(xtal.gen)
 
 #=
 """

--- a/src/software/vasp.jl
+++ b/src/software/vasp.jl
@@ -34,14 +34,14 @@ function readPOSCAR(io::IO; ctr=:P)
     else
         @warn string(
             "This POSCAR does not contain atomic identity information.\n",
-            "Dummy atoms will be used as placeholders."
+            "Dummy atoms will be used as placeholders, with names such as X1, X2, etc."
         )
         atomnames = String[]
     end
     # Get the number of each type of atom
     natomtypes = parse.(Int, split(ln))
     if isempty(atomnames)
-        atomnames = ["" for n in 1:length(natomtypes)]
+        atomnames = [string("X", n) for n in 1:length(natomtypes)]
     end
     # Find the "Direct" keyword
     while true


### PR DESCRIPTION
The new functionality should allow writing of VASP 4.6 format POSCAR files. There's also some additions such as `atomtypes()` and sorting an `AtomList` by atomic number.