### PR TITLE
Fix `supercell()`

### DIFF
--- a/src/atoms.jl
+++ b/src/atoms.jl
@@ -205,8 +205,10 @@ function supercell(l::AtomList{D}, M::AbstractMatrix{<:Integer}) where D
     # Conversion to upper triangular form should make this easier to work with
     scb = triangularize(basis(l), M)
     # Use LU decomposition to generate the translation bounds
+    decomp = lu(M)
     # Convert to a positive integer to generate valid indices
-    tmax = SVector{D,Int}(abs.(diag(lu(M).U)))
+    # Make sure that the matrix is correctly permuted for this process
+    tmax = SVector{D,Int}(abs.(diag(decomp.U))[decomp.p])
     # Generate all the sites in the supercell where new atoms have to be placed
     newpts = [(v.I .- 1) ./ tmax for v in CartesianIndices(Tuple(tmax))]
     # Shift everything over for each new point

--- a/src/atoms.jl
+++ b/src/atoms.jl
@@ -216,7 +216,8 @@ function supercell(l::AtomList{D}, M::AbstractMatrix{<:Integer}) where D
         AtomPosition(
             atomname(atom),
             atomicno(atom),
-            (v = M \ coord(atom) + d;  v - floor.(v)) # Keep the new atoms inside the supercell
+            # Keep the new atoms inside the supercell
+            (v = M \ coord(atom) + d;  SVector{D,Float64}(v - floor.(v)))
         )
         for atom in l.coord, d in newpts
     ]


### PR DESCRIPTION
It appears that calling it with an argument that wasn't an `SMatrix` or `SVector` would cause it to throw an error. This should be fixed now.

I also don't know if we needed to account for the permutations involved in the LU decomposition that's used to generate the supercell, but I've included code to do so.