### PR TITLE
New `AbstractBasis`, `RealBasis` and `ReciprocalBasis` types

### DIFF
--- a/src/Xtal.jl
+++ b/src/Xtal.jl
@@ -99,7 +99,7 @@ _selfdot(v) = dot(v,v)
 include("vectors.jl")
 # Abstract types used in type tree
 include("types.jl")
-export AbstractLattice, AbstractCrystal, AbstractCrystalData, AbstractRealSpaceData, 
+export AbstractBasis, AbstractLattice, AbstractCrystal, AbstractCrystalData, AbstractRealSpaceData,
        AbstractReciprocalSpaceData, AbstractHKL, AbstractKPoints, AbstractDensityOfStates,
        AbstractPotential, AbstractPseudopotential
 # Methods and structs for working with crystal lattices

--- a/src/Xtal.jl
+++ b/src/Xtal.jl
@@ -104,7 +104,7 @@ export AbstractBasis, AbstractLattice, AbstractCrystal, AbstractCrystalData, Abs
        AbstractPotential, AbstractPseudopotential
 # Methods and structs for working with crystal lattices
 include("lattices.jl")
-export BasisVectors, RealLattice, ReciprocalLattice
+export BasisVectors, RealBasis, ReciprocalBasis, RealLattice, ReciprocalLattice
 export triangularize, dual, prim, conv, cell_lengths, cell_volume, lengths, volume, lattice2D, 
        lattice3D, maxHKLindex
 # Methods and structs for working with atomic positions

--- a/src/lattices.jl
+++ b/src/lattices.jl
@@ -108,6 +108,23 @@ function (::Type{T})(M::AbstractMatrix{<:Real}) where {T<:AbstractBasis}
     return T(vs)
 end
 
+"""
+    convert(::Type{<:RealBasis}, b::ReciprocalBasis) -> RealBasis
+    convert(::Type{<:ReciprocalBasis}, b::RealBasis) -> ReciprocalBasis
+
+Converts between real space and reciprocal space representations of bases. Note that this includes
+a factor of 2π that is used conventionally in crystallography: conversion from `RealBasis` to
+`ReciprocalBasis` multiplies by 2π, and vice versa. This ensures that the dot products between
+corresponding real and reciprocal space basis vectors are always 2π.
+"""
+function Base.convert(::Type{<:RealBasis}, b::ReciprocalBasis)
+    return RealBasis(2π * inv(transpose(matrix(b))))
+end
+
+function Base.convert(::Type{<:ReciprocalBasis}, b::RealBasis)
+    return ReciprocalBasis(inv(transpose(matrix(b))) / 2π)
+end
+
 # Tools to generate 2D and 3D lattices with given angles
 #-------------------------------------------------------------------------------------------------#
 

--- a/src/lattices.jl
+++ b/src/lattices.jl
@@ -51,11 +51,6 @@ end
 BasisVectors(vs::Vararg{AbstractVector{<:Real}, D}) where D = BasisVectors{D}(hcat(vs...))
 BasisVectors{D}(vs::AbstractVector{<:AbstractVector}) where D = BasisVectors{D}(hcat(vs...))
 
-# TODO: might this be better off as an inner constructor?
-function BasisVectors(M::AbstractMatrix{<:Real})
-    return BasisVectors(SVector{D,SVector{D,Float64}}(M[:,n] for n in 1:D))
-end
-
 #---New RealBasis and ReciprocalBasis types-------------------------------------------------------#
 """
     RealBasis{D} <: AbstractBasis{D}

--- a/src/lattices.jl
+++ b/src/lattices.jl
@@ -24,7 +24,7 @@ function lattice_sanity_check(vs::AbstractVector{<:AbstractVector{<:Real}})
 end
 
 """
-    BasisVectors{D}
+    BasisVectors{D} <: AbstractBasis{D}
 
 Collection of `D` basis vectors spanning `D`-dimensional space.
 
@@ -35,7 +35,7 @@ length declaration that would be required by an `SMatrix`.
 indexing with a single value returns an `SVector{D,Float64}`, not a value as would happen with most
 subtypes of `AbstractMatrix`.
 """
-struct BasisVectors{D}
+struct BasisVectors{D} <: AbstractBasis{D}
     vs::SVector{D,SVector{D,Float64}}
     # TODO: there's probably a nicer way to handle this, but whatever
     # Inner constructor for all matrices

--- a/src/show.jl
+++ b/src/show.jl
@@ -29,21 +29,21 @@ function basis_string(
     # Letters should work up to 26 dimensions, but who's gonna deal with 26D crystals?
     # Bosonic string theorists, maybe?
     return [
-                pad * string(Char(0x60 + n), ':', ' ')^letters *
-                vector_string(M[:,n], brackets=brackets) *
-                ("   (" * tostr(norm(M[:,n]), 0))^length * " "^!isempty(unit) * unit * ")"
-                for n in 1:size(M)[2]
-            ]
+        pad * string(Char(0x60 + n), ':', ' ')^letters *
+        vector_string(M[:,n], brackets=brackets) *
+        ("   (" * tostr(norm(M[:,n]), 0))^length * " "^!isempty(unit) * unit * ")"
+        for n in 1:size(M)[2]
+    ]
 end
 
-basis_string(b::BasisVectors; kwargs...) = basis_string(matrix(b); kwargs...)
+basis_string(b::AbstractBasis; kwargs...) = basis_string(matrix(b); kwargs...)
 
 function printbasis(io::IO, M::AbstractMatrix{<:Real}; letters=true, unit="", pad=0)
     s = basis_string(M, letters=letters, unit=unit)
     print(io, join(" "^pad .* s, "\n"))
 end
 
-printbasis(io::IO, b::BasisVectors; kwargs...) = 
+printbasis(io::IO, b::AbstractBasis; kwargs...) = 
     printbasis(io::IO, matrix(b), letters=true, pad=0; kwargs...)
 printbasis(io::IO, a::AtomList; kwargs...) = 
     printbasis(io, basis(a), letters=true, pad=0; kwargs...)
@@ -93,9 +93,19 @@ will be reduced.
 """
 formula_string(a::AtomList{D}; reduce=true) where D = formula_string(a.coord, reduce=reduce)
 
-function Base.show(io::IO, ::MIME"text/plain", b::BasisVectors)
+function Base.show(io::IO, ::MIME"text/plain", b::AbstractBasis)
     println(io, typeof(b), ":")
     printbasis(io, b, pad=2)
+end
+
+function Base.show(io::IO, ::MIME"text/plain", b::RealBasis)
+    println(io, typeof(b), ":")
+    printbasis(io, b, pad=2, unit="Å")
+end
+
+function Base.show(io::IO, ::MIME"text/plain", b::ReciprocalBasis)
+    println(io, typeof(b), ":")
+    printbasis(io, b, pad=2, unit="Å⁻¹")
 end
 
 function Base.show(io::IO, ::MIME"text/plain", a::AtomPosition; name=true, num=true)

--- a/src/types.jl
+++ b/src/types.jl
@@ -12,6 +12,22 @@ strictly binding, but make sure that you know why you're breaking the rules if y
 =#
 
 """
+    AbstractBasis{D}
+
+Supertype for sets of basis vectors in `D` dimensions.
+
+This supertype includes the `BasisVectors{D}` type as well as the new `RealBasis{D}` and
+`ReciprocalBasis{D}` types, which explicitly indicate their units (assumed to be either angstroms
+or inverse angstroms).
+
+Members of `AbstractBasis` must implement the following checks:
+  * That the basis vectors are linearly independent and form a right-handed coordinate system, 
+unless an explicit zero basis is constructed (implying no periodicity).
+"""
+abstract type AbstractBasis{D}
+end
+
+"""
     AbstractLattice{D}
 
 Supertype for all lattices of dimension D.


### PR DESCRIPTION
Eventually these should replace `BasisVectors` as the favored representation of a set of crystal basis vectors, as they have a notion of units (`RealBasis` being in length and `ReciprocalBasis` being in inverse length). All of the functionality that `BasisVectors` has should be extended to `AbstractBasis`.

In the future I will refactor `AbstractLattice` and its subtypes to use these new types internally.