### PR TITLE
Adding energy and occupancy data to `ReciprocalWavefunction`

### DIFF
--- a/src/data/reciprocalspace.jl
+++ b/src/data/reciprocalspace.jl
@@ -468,3 +468,5 @@ Returns the number of bands associated with a `ReciprocalWavefunction`. It is as
 number of bands is the same for each k-point and spin.
 """
 nband(wf::ReciprocalWavefunction) = size(wf.waves, 3)
+
+basis(wf::ReciprocalWavefunction) = wf.rlatt

--- a/src/data/reciprocalspace.jl
+++ b/src/data/reciprocalspace.jl
@@ -439,8 +439,13 @@ function ReciprocalWavefunction(
     return ReciprocalWavefunction(M, kpts, waves, energies, occupancies)
 end
 
-# Getting indices should pull from the waves struct: wf[kpt, band]
-Base.getindex(wf::ReciprocalWavefunction{D,T}, inds...) where {D,T} = wf.waves[inds...]
+function Base.getindex(wf::ReciprocalWavefunction, i...)
+    return (
+        coeffs = wf.waves[inds...],
+        energies = wf.energies[inds...],
+        occupancies = wf.occupancies[inds...]
+    )
+end
 
 """
     nspin(wf::ReciprocalWavefunction) -> Int

--- a/src/software/vasp.jl
+++ b/src/software/vasp.jl
@@ -192,9 +192,7 @@ function readWAVECAR(io::IO)
             npw = Int(read(io, Float64))
             # Add the position of the k-point to the list
             klist[kp] = [read(io, Float64) for n = 1:3]
-            # Get the bands associated with the k-point
-            # bands[kp] = [(read(io, Float64), (skip(io, 8); read(io, Float64))) for b in 1:nband]
-            @debug "This is the problem line"
+            # Get energies and occupancies
             for b in 1:nband
                 energies[s,kp,b] = read(io, Float64)
                 skip(io, 8)


### PR DESCRIPTION
I've also added a definition of `basis()` for `ReciprocalWavefunction` for good measure.

Both `readWAVECAR()` and `read_abinit_wavefunction()` have been updated to include energy and occupancy data from the file in the returned `ReciprocalWavefunction`.