### PR TITLE
Fix broken sort export

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,7 @@ authors = [
     "Amber Lim <xalim@wisc.edu>", 
     "Patrick Cross <pcross@wisc.edu>"
 ]
-version = "0.1.25"
+version = "0.1.26"
 
 [deps]
 ComputedFieldTypes = "459fdd68-db75-56b8-8c15-d717a790f88e"

--- a/src/Xtal.jl
+++ b/src/Xtal.jl
@@ -110,7 +110,7 @@ export triangularize, dual, prim, conv, cell_lengths, cell_volume, lengths, volu
 # Methods and structs for working with atomic positions
 include("atoms.jl")
 export AtomPosition, AtomList
-export atomname, atomicno, sort_atomino, coord, natom, basis, cartesian, reduce_coords, supercell,
+export atomname, atomicno, sort_atomicno, coord, natom, basis, cartesian, reduce_coords, supercell,
        atomtypes, natomtypes
 # Methods and structs for working with crystal data
 include("crystals.jl")


### PR DESCRIPTION
It seems that `sort_atomicno()` was misspelled in the export directive, so this has now been fixed.