### PR TITLE
Fix reading alphabeta in `get_fermi` for VASP 6

### DIFF
--- a/src/software/vasp.jl
+++ b/src/software/vasp.jl
@@ -407,7 +407,7 @@ function get_fermi(io::IO)
     readuntil(io, "E-fermi :")
     ln = split(readline(io))
     fermi = parse.(Float64, ln[1]) .* EV2HARTREE
-    alphabeta = parse.(Float64, strip(ln[5],':')) .* EV2HARTREE
+    alphabeta = parse.(Float64, strip(ln[end],':')) .* EV2HARTREE
     return (fermi = fermi, alphabeta = alphabeta)
 end
 


### PR DESCRIPTION
VASP 6 has a space that throws off the parsing of `get_fermi`. This is fixed by using `ln[end]`.